### PR TITLE
Use event id instead of calender id (issue #32)

### DIFF
--- a/lib/app.php
+++ b/lib/app.php
@@ -452,8 +452,7 @@ class OC_Calendar_App{
 		if(OC_Calendar_Object::getowner($id) !== OCP\USER::getUser()) {
 			// do not show events with private or unknown access class
 			if (isset($vevent->CLASS)
-				&& ($vevent->CLASS->value === 'CONFIDENTIAL'
-				|| $vevent->CLASS->value === 'PRIVATE'
+				&& ($vevent->CLASS->value === 'PRIVATE'
 				|| $vevent->CLASS->value === ''))
 			{
 				return $output;

--- a/lib/app.php
+++ b/lib/app.php
@@ -452,7 +452,8 @@ class OC_Calendar_App{
 		if(OC_Calendar_Object::getowner($id) !== OCP\USER::getUser()) {
 			// do not show events with private or unknown access class
 			if (isset($vevent->CLASS)
-				&& ($vevent->CLASS->value === 'PRIVATE'
+				&& ($vevent->CLASS->value === 'CONFIDENTIAL'
+				|| $vevent->CLASS->value === 'PRIVATE'
 				|| $vevent->CLASS->value === ''))
 			{
 				return $output;

--- a/lib/export.php
+++ b/lib/export.php
@@ -76,7 +76,7 @@ class OC_Calendar_Export{
 				return '';
 			}
 		}
-		$object = OC_Calendar_Object::cleanByAccessClass($event['calendarid'], $object);
+		$object = OC_Calendar_Object::cleanByAccessClass($event['id'], $object);
 
 		if($object->VEVENT){
 			$dtstart = $object->VEVENT->DTSTART;

--- a/lib/object.php
+++ b/lib/object.php
@@ -457,14 +457,14 @@ class OC_Calendar_Object{
 
 	/**
 	 * @brief Remove all properties which should not be exported for the AccessClass Confidential
-	 * @param string $calendarId Calendar ID
+	 * @param string $id Event ID
 	 * @param Sabre_VObject $vobject Sabre VObject
 	 * @return object
 	 */
-	public static function cleanByAccessClass($calendarId, $vobject) {
+	public static function cleanByAccessClass($id, $vobject) {
 
 		// Do not clean your own calendar
-		if(OC_Calendar_Object::getowner($calendarId) === OCP\USER::getUser()) {
+		if(OC_Calendar_Object::getowner($id) === OCP\USER::getUser()) {
 			return $vobject;
 		}
 

--- a/lib/sabre/backend.php
+++ b/lib/sabre/backend.php
@@ -268,7 +268,7 @@ class OC_Connector_Sabre_CalDAV extends Sabre_CalDAV_Backend_Abstract {
 		$data = OC_Calendar_Object::findWhereDAVDataIs($calendarId,$objectUri);
 		if(is_array($data)) {
 			$object = OC_VObject::parse($data['calendardata']);
-			$object = OC_Calendar_Object::cleanByAccessClass($calendarId, $object);
+			$object = OC_Calendar_Object::cleanByAccessClass($data['id'], $object);
 			$data['calendardata'] = $object->serialize();
 			$data = $this->OCAddETag($data);
 		}


### PR DESCRIPTION
Object::getowner returns the owner of an event, not of a calendar. So we have do use event id instead of calender id  - this was a fault in my first feature-adding patch and only affects access via CalDAV. This patch should fix the issue #32.
