### PR TITLE
Share also confidential events (fixes issue #5)

### DIFF
--- a/lib/app.php
+++ b/lib/app.php
@@ -452,8 +452,7 @@ class OC_Calendar_App{
 		if(OC_Calendar_Object::getowner($id) !== OCP\USER::getUser()) {
 			// do not show events with private or unknown access class
 			if (isset($vevent->CLASS)
-				&& ($vevent->CLASS->value === 'CONFIDENTIAL'
-				|| $vevent->CLASS->value === 'PRIVATE'
+				&& ($vevent->CLASS->value === 'PRIVATE'
 				|| $vevent->CLASS->value === ''))
 			{
 				return $output;


### PR DESCRIPTION
This patch allows to share confidential events (#5), only private or unknown class will not be shared.
