### PR TITLE
More robust event sharing - fixes 142

### DIFF
--- a/lib/share/event.php
+++ b/lib/share/event.php
@@ -30,16 +30,16 @@ class OC_Share_Backend_Event implements OCP\Share_Backend {
 	public function formatItems($items, $format, $parameters = null) {
 		$events = array();
 		if ($format == self::FORMAT_EVENT) {
-            foreach ($items as $item) {
-                $event = OC_Calendar_Object::find($item['item_source']);
-                if ($event == False) {  
-                    \OCP\Util::writeLog('calendar', __METHOD__.', Missing event: ' . $item['item_target'], \OCP\Util::DEBUG);
-                }
-                else {
-                    $event['summary'] = $item['item_target'];
-                    $event['permissions'] = $item['permissions'];
-                    $events[] = $event;
-                }
+			foreach ($items as $item) {
+				$event = OC_Calendar_Object::find($item['item_source']);
+				if ($event == False) {
+					\OCP\Util::writeLog('calendar', __METHOD__.', Missing event: ' . $item['item_target'], \OCP\Util::DEBUG);
+				}
+				else {
+					$event['summary'] = $item['item_target'];
+					$event['permissions'] = $item['permissions'];
+					$events[] = $event;
+				}
 			}
 		}
 		return $events;

--- a/lib/share/event.php
+++ b/lib/share/event.php
@@ -30,11 +30,10 @@ class OC_Share_Backend_Event implements OCP\Share_Backend {
 	public function formatItems($items, $format, $parameters = null) {
 		$events = array();
 		if ($format == self::FORMAT_EVENT) {
-			foreach ($items as $item) {
-				$event = OC_Calendar_Object::find($item['item_source']);
-                if ($event == False) {
-                    error_log(var_export($item['item_target'], true));
-                      \OCP\Util::writeLog('calendar', __METHOD__.', Missing event: ' . $item['item_target'], \OCP\Util::DEBUG);
+            foreach ($items as $item) {
+                $event = OC_Calendar_Object::find($item['item_source']);
+                if ($event == False) {  
+                    \OCP\Util::writeLog('calendar', __METHOD__.', Missing event: ' . $item['item_target'], \OCP\Util::DEBUG);
                 }
                 else {
                     $event['summary'] = $item['item_target'];

--- a/lib/share/event.php
+++ b/lib/share/event.php
@@ -32,9 +32,15 @@ class OC_Share_Backend_Event implements OCP\Share_Backend {
 		if ($format == self::FORMAT_EVENT) {
 			foreach ($items as $item) {
 				$event = OC_Calendar_Object::find($item['item_source']);
-				$event['summary'] = $item['item_target'];
-				$event['permissions'] = $item['permissions'];
-				$events[] = $event;
+                if ($event == False) {
+                    error_log(var_export($item['item_target'], true));
+                      \OCP\Util::writeLog('calendar', __METHOD__.', Missing event: ' . $item['item_target'], \OCP\Util::DEBUG);
+                }
+                else {
+                    $event['summary'] = $item['item_target'];
+                    $event['permissions'] = $item['permissions'];
+                    $events[] = $event;
+                }
 			}
 		}
 		return $events;


### PR DESCRIPTION
I got two databases where all shared events disappeared. I cant reproduce how this happened, but with this fix the broken events  get filted and a msg goes into the log. All working events are visible. 

owncloud/apps/calendar/ajax/events.php#33 fails because it gets a incomplete array.

The problem is, that events are oc_shared but not in oc_clndr_objects. 

Hope this helps, and we find a way to reproduce and the real problem.

This fix can go into master, too.
