### PR TITLE
Cast translated displayname to string in CalDAV bday calendar

### DIFF
--- a/lib/sabre/backend.php
+++ b/lib/sabre/backend.php
@@ -63,7 +63,7 @@ class OC_Connector_Sabre_CalDAV extends Sabre_CalDAV_Backend_Abstract {
 			$calendars[] = array(
 				'id' => 'contact_birthdays',
 				'uri' => 'contact_birthdays',
-				'{DAV:}displayname' => OC_Calendar_App::$l10n->t('Contact birthdays'),
+				'{DAV:}displayname' => (string)OC_Calendar_App::$l10n->t('Contact birthdays'),
 				'principaluri' => 'principals/contact_birthdays',
 				'{' . Sabre_CalDAV_Plugin::NS_CALENDARSERVER . '}getctag' => '0',
 				'{' . Sabre_CalDAV_Plugin::NS_CALDAV . '}supported-calendar-component-set'


### PR DESCRIPTION
I just noticed an error in my previous PR that made actual sync fail with:

``` xml
<?xml version="1.0" encoding="utf-8"?>
<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
  <s:exception>Sabre_DAV_Exception</s:exception>
  <s:message>Unknown property value type: object for property: {DAV:}displayname</s:message>
  <s:sabredav-version>1.7.6</s:sabredav-version>
</d:error>
```

@georgehrke 
