### PR TITLE
Fix calendar annoyances

### DIFF
--- a/ajax/changeview.php
+++ b/ajax/changeview.php
@@ -12,7 +12,7 @@ $view = $_POST['v'];
 switch($view) {
 	case 'agendaWeek':
 	case 'month';
-	case 'list':
+	case 'agendaDay':
 		break;
 	default:
 		OCP\JSON::error(array('message'=>'unexpected parameter: ' . $view));

--- a/css/style.css
+++ b/css/style.css
@@ -134,3 +134,19 @@ button.category{margin:0 3px;}
 	font-size: 20px;
 	margin: 0;
 }
+
+.ui-dialog {
+	height: 94% !important;
+	top: 4% !important;
+	overflow-y: auto;
+	overflow-x: hidden;
+	padding: 0;
+}
+.ui-dialog .ui-dialog-content {
+	overflow: none;
+}
+#appsettings_popup {
+	height: 70%;
+	overflow-y: auto;
+	overflow-x: hidden;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -122,3 +122,15 @@ button.category{margin:0 3px;}
 .link{
 	color:#148cf6;
 }
+
+
+
+
+
+#event-title {
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
+	width: 100%;
+	font-size: 20px;
+	margin: 0;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -135,19 +135,72 @@ button.category{margin:0 3px;}
 	font-weight: bold;
 }
 
-/* bigger event title in detail view */
-#event-title {
+/* input fields take whole width */
+#event-title,
+#event-location,
+#category,
+#event-description {
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 	width: 100%;
+	margin: 3px 0;
+}
+/* bigger event title in detail view */
+#event-title {
 	font-size: 20px;
+}
+/* group from and to date fields */
+#event-time {
+	display: block;
+	margin: 5px 0;
+}
+#event-time-from {
+	float: left;
+}
+#event-time-to {
+	float: right;
+}
+#from, #to {
+	width: 65px;
 	margin: 0;
 }
+#fromtime, #totime {
+	margin: 0;
+}
+#event-allday {
+	display: inline-block;
+	margin: 7px 0;
+}
+/* category input field leaves room for edit button */
+#category {
+	width: 90%;
+}
+#editCategories {
+	display: inline-block;
+	padding: 6px 12px;
+}
+/* whole line for buttons of 'Advanced' and 'Export' */
+#advanced_options_button,
+#editEvent-export {
+	display: block;
+	margin: 0;
+}
+/* normal font weight for secondary buttons for less obtrusiveness */
+#advanced_options_button,
+#editEvent-export,
+#editEvent-delete {
+	font-weight: normal;
+}
+/* more space for action buttons below */
+#actions {
+	height: 45px;
+}
+
 
 /* make popups scrollable in smaller viewports */
 .ui-dialog {
-	height: 94% !important;
-	top: 4% !important;
+	max-height: 80% !important;
+	top: 10% !important;
 	overflow-y: auto;
 	overflow-x: hidden;
 	padding: 0;
@@ -156,7 +209,7 @@ button.category{margin:0 3px;}
 	overflow: initial;
 }
 #appsettings_popup {
-	height: 70%;
+	max-height: 70%;
 	overflow-y: auto;
 	overflow-x: hidden;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -61,8 +61,6 @@ button.category{margin:0 3px;}
 #event {padding: 0;margin: 0;margin-top:-5px}
 
 .sharedby li .shareactions { float: right; }
-.sharedby li > .shareactions > * { display: none; }
-.sharedby li:hover > .shareactions > * { display: inline-block; }
 
 .fc-state-highlight { background: #ffa; }
 
@@ -155,7 +153,7 @@ button.category{margin:0 3px;}
 	padding: 0;
 }
 .ui-dialog .ui-dialog-content {
-	overflow: none;
+	overflow: initial;
 }
 #appsettings_popup {
 	height: 70%;

--- a/css/style.css
+++ b/css/style.css
@@ -123,7 +123,7 @@ button.category{margin:0 3px;}
 }
 
 
-
+/* fit buttons to control bar */
 #controls input[type="button"] {
 	height: 38px;
 	margin: 0;
@@ -137,6 +137,7 @@ button.category{margin:0 3px;}
 	font-weight: bold;
 }
 
+/* bigger event title in detail view */
 #event-title {
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
@@ -145,6 +146,7 @@ button.category{margin:0 3px;}
 	margin: 0;
 }
 
+/* make popups scrollable in smaller viewports */
 .ui-dialog {
 	height: 94% !important;
 	top: 4% !important;
@@ -159,4 +161,20 @@ button.category{margin:0 3px;}
 	height: 70%;
 	overflow-y: auto;
 	overflow-x: hidden;
+}
+
+/* color weekends */
+.fc-sat, .fc-sun {
+	background-color: #f8f8f8;
+}
+
+/* don't bold weekday names in header */
+#fullcalendar th {
+	font-weight: normal;
+	color: #aaa;
+}
+
+/* lighter border color */
+.fc-widget-header, .fc-widget-content {
+	border: 1px solid #e8e8e8;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -46,7 +46,6 @@
 .event {position:relative;}
 .event.colored {border-bottom: 1px solid white;}
 
-input[type="button"].active {color: #6193CF}
 #fromtime, #totime {
 color:#333;
 }
@@ -125,7 +124,18 @@ button.category{margin:0 3px;}
 
 
 
-
+#controls input[type="button"] {
+	height: 38px;
+	margin: 0;
+	font-weight: normal;
+}
+#controls #view, #controls #datecontrol {
+	margin: 3px;
+}
+#controls #datecontrol_date,
+#controls input[type="button"].active {
+	font-weight: bold;
+}
 
 #event-title {
 	-moz-box-sizing: border-box;

--- a/css/style.css
+++ b/css/style.css
@@ -110,34 +110,6 @@ button.category{margin:0 3px;}
 {
      cursor: pointer;
 }
-.tipsy-event .tipsy-inner{
-background-color:#0098E4;
-border:2px solid #1d2d44;
-max-width:400px;
-padding:0;
-}
-.tipsy-event .tipsy-arrow-s{
-border-top-color:#1d2d44;
-}
-.tipsy-event .tipsy-arrow-n{
-border-bottom-color:#1d2d44;
-}
-.tipsy-event .summary,
-.tipsy-event .timespan,
-.tipsy-event .description{
-padding:0 8px;
-}
-.tipsy-event .summary{
-background-color:#1d2d44;
-font-size:1.2em;
-font-weight:bold;
-text-align:left;
-padding:0 8px 2px;
-}
-.tipsy-event .description{
-line-height:1.2;
-margin-bottom:4px;
-}
 
 #fullcalendar{
 	overflow: auto;

--- a/css/style.css
+++ b/css/style.css
@@ -58,7 +58,11 @@ button.category{margin:0 3px;}
 .calendar-colorpicker-color{display:inline-block;width:20px;height:20px;margin-right:2px;cursor:pointer;border:2px solid transparent;}
 .calendar-colorpicker-color.active{border:2px solid black;}
 
-#event {padding: 0;margin: 0;margin-top:-5px}
+#event {
+	height: initial !important;
+	padding: 0;
+	margin: -5px 0 5px;
+}
 
 .sharedby li .shareactions { float: right; }
 
@@ -199,8 +203,8 @@ button.category{margin:0 3px;}
 
 /* make popups scrollable in smaller viewports */
 .ui-dialog {
-	max-height: 80% !important;
-	top: 10% !important;
+	max-height: 75% !important;
+	top: 15% !important;
 	overflow-y: auto;
 	overflow-x: hidden;
 	padding: 0;

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -570,9 +570,9 @@ Calendar={
 								+ 'data-share-with="'+shareWith+'" '
 								+ 'data-permissions="'+permissions+'" '
 								+ 'data-share-type="'+shareType+'">'+shareWith+' ('+(shareType == OC.Share.SHARE_TYPE_USER ? t('core', 'user') : t('core', 'group'))+')'
-								+ '<span class="shareactions"><input class="update" type="checkbox" title="'+t('core', 'Editable')+'">'
-								+ '<input class="share" type="checkbox" title="'+t('core', 'Shareable')+'" checked="checked">'
-								+ '<input class="delete" type="checkbox" title="'+t('core', 'Deletable')+'">'
+								+ '<span class="shareactions"><label><input class="update" type="checkbox" checked="checked">'+t('core', 'can edit')+'</label>'
+								+ '<input class="share" type="checkbox" checked="checked">'+t('core', 'can share')+'</label>'
+								+ '<input class="delete" type="checkbox" checked="checked">'+t('core', 'can delete')+'</label>'
 								+ '<img class="svg action delete" title="Unshare"src="'+ OC.imagePath('core', 'actions/delete.svg') +'"></span></li>';
 							$('.sharedby.eventlist').append(newitem);
 							$('#sharedWithNobody').remove();

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -126,6 +126,7 @@ Calendar={
 			$('#event').dialog({
 				width : 500,
 				height: 600,
+				resizable: false,
 				close : function(event, ui) {
 					$(this).dialog('destroy').remove();
 				}

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -401,8 +401,8 @@ Calendar={
 				case 'month':
 					id = 'onemonthview_radio';
 					break;
-				case 'list':
-					id = 'listview_radio';
+				case 'agendaDay':
+					id = 'onedayview_radio';
 					break;
 			}
 			$('#'+id).addClass('active');
@@ -868,6 +868,11 @@ $(document).ready(function(){
 				$.post(OC.filePath('calendar', 'ajax', 'changeview.php'), {v:view.name});
 				defaultView = view.name;
 			}
+			if(view.name === 'agendaDay') {
+				$('td.fc-state-highlight').css('background-color', '#ffffff');
+			} else{
+				$('td.fc-state-highlight').css('background-color', '#ffc');
+			}
 			Calendar.UI.setViewActive(view.name);
 			if (view.name == 'agendaWeek') {
 				$('#fullcalendar').fullCalendar('option', 'aspectRatio', 0.1);
@@ -921,8 +926,8 @@ $(document).ready(function(){
 	$('#onemonthview_radio').click(function(){
 		$('#fullcalendar').fullCalendar('changeView', 'month');
 	});
-	$('#listview_radio').click(function(){
-		$('#fullcalendar').fullCalendar('changeView', 'list');
+	$('#onedayview_radio').click(function(){
+		$('#fullcalendar').fullCalendar('changeView', 'agendaDay');
 	});
 	$('#today_input').click(function(){
 		$('#fullcalendar').fullCalendar('today');

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -93,7 +93,6 @@ Calendar={
 		},
 		startEventDialog:function(){
 			Calendar.UI.loading(false);
-			$('.tipsy').remove();
 			$('#fullcalendar').fullCalendar('unselect');
 			Calendar.UI.lockTime();
 			$( "#from" ).datepicker({
@@ -220,7 +219,6 @@ Calendar={
 				},"json");
 		},
 		moveEvent:function(event, dayDelta, minuteDelta, allDay, revertFunc){
-			$('.tipsy').remove();
 			Calendar.UI.loading(true);
 			$.post(OC.filePath('calendar', 'ajax/event', 'move.php'), { id: event.id, dayDelta: dayDelta, minuteDelta: minuteDelta, allDay: allDay?1:0, lastmodified: event.lastmodified},
 			function(data) {
@@ -235,7 +233,6 @@ Calendar={
 			});
 		},
 		resizeEvent:function(event, dayDelta, minuteDelta, revertFunc){
-			$('.tipsy').remove();
 			Calendar.UI.loading(true);
 			$.post(OC.filePath('calendar', 'ajax/event', 'resize.php'), { id: event.id, dayDelta: dayDelta, minuteDelta: minuteDelta, lastmodified: event.lastmodified},
 			function(data) {
@@ -306,7 +303,6 @@ Calendar={
 				return;
 			}
 			$('#fullcalendar').fullCalendar('option', 'height', $(window).height() - $('#controls').height() - $('#header').height() - 15);
-			$('.tipsy').remove();
 			var direction;
 			if(event.detail){
 				if(event.detail < 0){
@@ -940,17 +936,6 @@ $(document).ready(function(){
 		eventResize: Calendar.UI.resizeEvent,
 		eventRender: function(event, element) {
 			element.find('.fc-event-title').text($("<div/>").html(escapeHTML(event.title)).text())
-			element.tipsy({
-				className: 'tipsy-event',
-				opacity: 0.9,
-				gravity:$.fn.tipsy.autoBounds(150, 's'),
-				fade:true,
-				delayIn: 400,
-				html:true,
-				title:function() {
-					return Calendar.UI.getEventPopupText(event);
-				}
-			});
 		},
 		loading: Calendar.UI.loading,
 		eventSources: eventSources

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -127,6 +127,7 @@ Calendar={
 				width : 500,
 				height: 600,
 				resizable: false,
+				draggable: false,
 				close : function(event, ui) {
 					$(this).dialog('destroy').remove();
 				}

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -83,7 +83,6 @@ Calendar={
 		}
 	},
 	UI:{
-		scrollcount: 0,
 		loading: function(isLoading){
 			if (isLoading){
 				$('#loading').show();
@@ -289,53 +288,6 @@ Calendar={
 			$('#caldav_url').val(totalurl + '/' + username + '/' + calname);
 			$('#caldav_url').show();
 			$("#caldav_url_close").show();
-		},
-		initScroll:function(){
-			if(window.addEventListener)
-				document.addEventListener('DOMMouseScroll', Calendar.UI.scrollCalendar, false);
-			//}else{
-				document.onmousewheel = Calendar.UI.scrollCalendar;
-			//}
-		},
-		scrollCalendar:function(event){
-			var currentView = $('#fullcalendar').fullCalendar('getView');
-			if(currentView.name == 'agendaWeek') {
-				return;
-			}
-			$('#fullcalendar').fullCalendar('option', 'height', $(window).height() - $('#controls').height() - $('#header').height() - 15);
-			var direction;
-			if(event.detail){
-				if(event.detail < 0){
-					direction = 'top';
-				}else{
-					direction = 'down';
-				}
-			}
-			if (event.wheelDelta){
-				if(event.wheelDelta > 0){
-					direction = 'top';
-				}else{
-					direction = 'down';
-				}
-			}
-			Calendar.UI.scrollcount++;
-			if(Calendar.UI.scrollcount < 20){
-				return;
-			}
-
-			var scroll = $(document).scrollTop(),
-				doc_height = $(document).height(),
-				win_height = $(window).height();
-			if(direction == 'down'/* && win_height == (doc_height - scroll)*/){
-				$('#fullcalendar').fullCalendar('next');
-				$(document).scrollTop(0);
-				event.preventDefault();
-			}else/* if (direction == 'top' && scroll == 0) */{
-				$('#fullcalendar').fullCalendar('prev');
-				$(document).scrollTop(win_height);
-				event.preventDefault();
-			}
-			Calendar.UI.scrollcount = 0;
 		},
 		repeat:function(task){
 			if(task=='init'){
@@ -882,7 +834,6 @@ function ListView(element, calendar) {
 	}
 }
 $(document).ready(function(){
-	Calendar.UI.initScroll();
 	$('#fullcalendar').fullCalendar({
 		header: false,
 		firstDay: firstDay,

--- a/lib/object.php
+++ b/lib/object.php
@@ -528,9 +528,9 @@ class OC_Calendar_Object{
 	 */
 	public static function getAccessClassOptions($l10n) {
 		return array(
-			'PUBLIC'       => (string)$l10n->t('Public'),
-			'PRIVATE'      => (string)$l10n->t('Private'),
-			'CONFIDENTIAL' => (string)$l10n->t('Confidential')
+			'PUBLIC'       => (string)$l10n->t('Show full event'),
+			'PRIVATE'      => (string)$l10n->t('Show only busy'),
+			'CONFIDENTIAL' => (string)$l10n->t('Hide event')
 		);
 	}
 

--- a/templates/calendar.php
+++ b/templates/calendar.php
@@ -6,6 +6,7 @@
 		<input type="button" value="<?php p($l->t('Day'));?>" id="onedayview_radio"/>
 		<input type="button" value="<?php p($l->t('Week'));?>" id="oneweekview_radio"/>
 		<input type="button" value="<?php p($l->t('Month'));?>" id="onemonthview_radio"/>&nbsp;&nbsp;
+		<img id="loading" src="<?php print_unescaped(OCP\Util::imagePath('calendar', 'loading.gif')); ?>" />
 	</form>
 	<form id="choosecalendar">
 		<!--<input type="button" id="today_input" value="<?php p($l->t("Today"));?>"/>-->

--- a/templates/calendar.php
+++ b/templates/calendar.php
@@ -3,10 +3,9 @@
 <div id="notification" style="display:none;"></div>
 <div id="controls">
 	<form id="view">
+		<input type="button" value="<?php p($l->t('Day'));?>" id="onedayview_radio"/>
 		<input type="button" value="<?php p($l->t('Week'));?>" id="oneweekview_radio"/>
-		<input type="button" value="<?php p($l->t('Month'));?>" id="onemonthview_radio"/>
-		<input type="button" value="<?php p($l->t('List'));?>" id="listview_radio"/>&nbsp;&nbsp;
-		<img id="loading" src="<?php print_unescaped(OCP\Util::imagePath('calendar', 'loading.gif')); ?>" />
+		<input type="button" value="<?php p($l->t('Month'));?>" id="onemonthview_radio"/>&nbsp;&nbsp;
 	</form>
 	<form id="choosecalendar">
 		<!--<input type="button" id="today_input" value="<?php p($l->t("Today"));?>"/>-->

--- a/templates/part.editcalendar.php
+++ b/templates/part.editcalendar.php
@@ -15,15 +15,6 @@
 	</td>
 </tr>
 <?php if (!$_['new']): ?>
-<tr>
-	<td></td>
-	<td>
-		<input id="edit_active_<?php p($_['calendar']['id']) ?>" type="checkbox"<?php p($_['calendar']['active'] ? ' checked="checked"' : '') ?>>
-		<label for="edit_active_<?php p($_['calendar']['id']) ?>">
-			<?php p($l->t('Active')) ?>
-		</label>
-	</td>
-</tr>
 <?php endif; ?>
 <tr>
 	<th><?php p($l->t('Calendar color')) ?></th>

--- a/templates/part.editevent.php
+++ b/templates/part.editevent.php
@@ -1,13 +1,12 @@
-<div id="event" title="<?php p($l->t("Edit an event"));?>">
+<div id="event" title="<?php p($l->t("Edit event"));?>">
 	<form id="event_form">
 		<input type="hidden" name="id" value="<?php p($_['eventid']) ?>">
 		<input type="hidden" name="lastmodified" value="<?php p($_['lastmodified']) ?>">
 <?php print_unescaped($this->inc("part.eventform")); ?>
 	<div style="width: 100%;text-align: center;color: #FF1D1D;" id="errorbox"></div>
 	<div id="actions">
-		<input type="button" class="submit actionsfloatleft" id="editEvent-submit" value="<?php p($l->t("Submit"));?>" data-link="<?php print_unescaped(OCP\Util::linkTo('calendar', 'ajax/event/edit.php')) ?>">
-		<input type="button" class="submit actionsfloatleft" id="editEvent-delete"  name="delete" value="<?php p($l->t("Delete"));?>" data-link="<?php print_unescaped(OCP\Util::linkTo('calendar', 'ajax/event/delete.php')) ?>">
-		<input type="button" class="submit actionsfloatright" id="editEvent-export"  name="export" value="<?php p($l->t("Export"));?>" data-link="<?php print_unescaped(OCP\Util::linkTo('calendar', 'export.php')) ?>?eventid=<?php p($_['eventid']) ?>">
+		<input type="button" class="submit actionsfloatright primary" id="editEvent-submit" value="<?php p($l->t('Save event'));?>" data-link="<?php print_unescaped(OCP\Util::linkTo('calendar', 'ajax/event/edit.php')) ?>">
+		<input type="button" class="submit actionsfloatleft" id="editEvent-delete"  name="delete" value="<?php p($l->t('Delete event'));?>" data-link="<?php print_unescaped(OCP\Util::linkTo('calendar', 'ajax/event/delete.php')) ?>">
 	</div>
 	</form>
 </div>

--- a/templates/part.eventform.php
+++ b/templates/part.eventform.php
@@ -11,97 +11,59 @@
 	<?php } ?>
 </ul>
 <div id="tabs-1">
-	<table width="100%">
-		<tr>
-			<th width="75px"><?php p($l->t("Title"));?>:</th>
-			<td>
-				<input type="text" style="width:350px;" size="100" placeholder="<?php p($l->t("Title of the Event"));?>" value="<?php p(isset($_['title']) ? $_['title'] : '') ?>" maxlength="100" name="title" autofocus="autofocus"/>
-			</td>
-		</tr>
-	</table>
-	<table width="100%">
-		<tr>
-			<th width="75px"><?php p($l->t("Category"));?>:</th>
-			<td>
-				<input id="category" name="categories" type="text" placeholder="<?php p($l->t('Separate categories with commas')); ?>" value="<?php p(isset($_['categories']) ? $_['categories'] : '') ?>">
-				<a class="action edit" id="editCategories" title="<?php p($l->t('Edit categories')); ?>"><img alt="<?php p($l->t('Edit categories')); ?>" src="<?php print_unescaped(OCP\image_path('core','actions/rename.svg'))?>" class="svg action" style="width: 16px; height: 16px;"></a>
-			</td>
-			<?php if(count($_['calendar_options']) > 1) { ?>
-			<th width="75px">&nbsp;&nbsp;&nbsp;<?php p($l->t("Calendar"));?>:</th>
-			<td>
-				<select style="width:140px;" name="calendar">
-					<?php
-					if (!isset($_['calendar'])) {$_['calendar'] = false;}
-					print_unescaped(OCP\html_select_options($_['calendar_options'], $_['calendar'], array('value'=>'id', 'label'=>'displayname')));
-					?>
-				</select>
-			</td>
-			<?php } else { ?>
-			<th width="75px">&nbsp;</th>
-			<td>
-				<input type="hidden" name="calendar" value="<?php p($_['calendar_options'][0]['id']); ?>">
-			</td>
-			<?php } ?>
-		</tr>
-		<tr>
-			<th width="75px"><?php p($l->t("Access Class"));?>:</th>
-			<td>
-				<select style="width:140px;" name="accessclass">
-					<?php
-					if (!isset($_['calendar'])) {$_['calendar'] = false;}
-					print_unescaped(OCP\html_select_options($_['access_class_options'], $_['accessclass']));
-					?>
-				</select>
-			</td>
-		</tr>
-	</table>
-	<hr>
-	<table width="100%">
-		<tr>
-			<th width="75px"></th>
-			<td>
-				<input type="checkbox"<?php if($_['allday']) {print_unescaped('checked="checked"');} ?> id="allday_checkbox" name="allday">
-				<label for="allday_checkbox"><?php p($l->t("All Day Event"));?></label>
-			</td>
-		</tr>
-		<tr>
-			<th width="75px"><?php p($l->t("From"));?>:</th>
-			<td>
-				<input type="text" value="<?php p($_['startdate']);?>" name="from" id="from">
-				&nbsp;&nbsp;
-				<input type="time" value="<?php p($_['starttime']);?>" name="fromtime" id="fromtime">
-			</td>
-		</tr>
-		<tr>
-			<th width="75px"><?php p($l->t("To"));?>:</th>
-			<td>
-				<input type="text" value="<?php p($_['enddate']);?>" name="to" id="to">
-				&nbsp;&nbsp;
-				<input type="time" value="<?php p($_['endtime']);?>" name="totime" id="totime">
-			</td>
-		</tr>
-	</table>
-	<input type="button" class="submit" value="<?php p($l->t("Advanced options")); ?>" id="advanced_options_button">
+	<input id="event-title" type="text" size="100"
+		placeholder="<?php p($l->t('Title of the Event'));?>"
+		value="<?php p(isset($_['title']) ? $_['title'] : '') ?>"
+		maxlength="100" name="title" autofocus="autofocus"/>
+
+	<?php if(count($_['calendar_options']) > 1) { ?>
+	<?php p($l->t("Calendar"));?>
+	<select style="width:140px;" name="calendar">
+		<?php if (!isset($_['calendar'])) {$_['calendar'] = false;}
+		print_unescaped(OCP\html_select_options($_['calendar_options'], $_['calendar'], array('value'=>'id', 'label'=>'displayname'))); ?>
+	</select>
+	<?php } else { ?>
+	<input style="display:none;" type="hidden" name="calendar" value="<?php p($_['calendar_options'][0]['id']); ?>">
+	<?php } ?>
+
+	<div id="event-time">
+		<div id="event-time-from">
+			<?php p($l->t('from'));?>
+			<input type="text" value="<?php p($_['startdate']);?>" name="from" id="from">
+			<input type="time" value="<?php p($_['starttime']);?>" name="fromtime" id="fromtime">
+		</div>
+		<div id="event-time-to">
+			<?php p($l->t('to'));?>
+			<input type="text" value="<?php p($_['enddate']);?>" name="to" id="to">
+			<input type="time" value="<?php p($_['endtime']);?>" name="totime" id="totime">
+		</div>
+	</div>
+
+	<label id="event-allday">
+		<input id="allday_checkbox" type="checkbox"<?php if($_['allday']) {print_unescaped('checked="checked"');} ?> name="allday">
+		<?php p($l->t("All Day Event"));?>
+	</label>
+
+	<input id="advanced_options_button" type="button" class="submit" value="<?php p($l->t('Advanced options')); ?>">
+
 	<div id="advanced_options" style="display: none;">
-		<hr>
-		<table>
-			<tr>
-				<th width="85px"><?php p($l->t("Location"));?>:</th>
-				<td>
-					<input type="text" style="width:350px;" size="100" placeholder="<?php p($l->t("Location of the Event"));?>" value="<?php p(isset($_['location']) ? $_['location'] : '') ?>" maxlength="100"  name="location" />
-				</td>
-			</tr>
-		</table>
-		<table>
-			<tr>
-				<th width="85px" style="vertical-align: top;"><?php p($l->t("Description"));?>:</th>
-				<td>
-					<textarea style="width:350px;height: 150px;" placeholder="<?php p($l->t("Description of the Event"));?>" name="description"><?php p(isset($_['description']) ? $_['description'] : '') ?></textarea>
-				</td>
-			</tr>
-		</table>
+		<input id="event-location" type="text" size="100"
+			placeholder="<?php p($l->t('Location'));?>"
+			value="<?php p(isset($_['location']) ? $_['location'] : '') ?>"
+			maxlength="100"  name="location" />
+
+		<input id="category" name="categories" type="text"
+			placeholder="<?php p($l->t('Categories (separate by comma)')); ?>"
+			value="<?php p(isset($_['categories']) ? $_['categories'] : '') ?>">
+		<a class="action edit" id="editCategories" title="<?php p($l->t('Edit categories')); ?>">
+		<img alt="<?php p($l->t('Edit categories')); ?>" src="<?php print_unescaped(OCP\image_path('core','actions/rename.svg'))?>" class="svg action" style="width: 16px; height: 16px;"></a>
+
+		<textarea id="event-description" placeholder="<?php p($l->t('Description'));?>" name="description"><?php p(isset($_['description']) ? $_['description'] : '') ?></textarea>
+
+		<input type="button" class="submit" id="editEvent-export"  name="export" value="<?php p($l->t('Export event'));?>" data-link="<?php print_unescaped(OCP\Util::linkTo('calendar', 'export.php')) ?>?eventid=<?php p($_['eventid']) ?>">
 	</div>
-	</div>
+</div>
+
 <div id="tabs-2">
 	<table style="width:100%">
 			<tr>
@@ -255,5 +217,12 @@
 <?php if($_['eventid'] != 'new' && $_['permissions'] & OCP\PERMISSION_SHARE) { ?>
 <div id="tabs-5">
 	<?php if($_['eventid'] != 'new') { print_unescaped($this->inc('part.share')); } ?>
+
+	<br>
+	<?php p($l->t('Visibility to people shared with'));?>
+	<select style="width:140px;" name="accessclass">
+		<?php if (!isset($_['calendar'])) {$_['calendar'] = false;}
+		print_unescaped(OCP\html_select_options($_['access_class_options'], $_['accessclass'])); ?>
+	</select>
 </div>
 <?php } ?>

--- a/templates/part.newevent.php
+++ b/templates/part.newevent.php
@@ -3,7 +3,9 @@
 <?php print_unescaped($this->inc("part.eventform")); ?>
 	<div style="width: 100%;text-align: center;color: #FF1D1D;" id="errorbox"></div>
 	<div id="actions">
-		<input type="button" id="submitNewEvent" data-link="<?php print_unescaped(OCP\Util::linkTo('calendar', 'ajax/event/new.php')); ?>" class="submit actionsfloatleft"  value="<?php p($l->t('Create event'));?>">
+		<input type="button" id="submitNewEvent" class="submit actionsfloatright primary"
+			data-link="<?php print_unescaped(OCP\Util::linkTo('calendar', 'ajax/event/new.php')); ?>"
+			value="<?php p($l->t('Create event'));?>">
 	</div>
 	</form>
 </div>

--- a/templates/part.newevent.php
+++ b/templates/part.newevent.php
@@ -3,7 +3,7 @@
 <?php print_unescaped($this->inc("part.eventform")); ?>
 	<div style="width: 100%;text-align: center;color: #FF1D1D;" id="errorbox"></div>
 	<div id="actions">
-		<input type="button" id="submitNewEvent" data-link="<?php print_unescaped(OCP\Util::linkTo('calendar', 'ajax/event/new.php')); ?>" class="submit actionsfloatleft"  value="<?php p($l->t("Submit"));?>">
+		<input type="button" id="submitNewEvent" data-link="<?php print_unescaped(OCP\Util::linkTo('calendar', 'ajax/event/new.php')); ?>" class="submit actionsfloatleft"  value="<?php p($l->t('Create event'));?>">
 	</div>
 	</form>
 </div>

--- a/templates/part.share.php
+++ b/templates/part.share.php
@@ -41,12 +41,18 @@ if(is_array($sharedwithByEvent)) {
 		data-share-type="<?php p($sharee['share_type']); ?>">
 		<?php p($sharee['share_with'] . ' (' . ($sharee['share_type'] == OCP\Share::SHARE_TYPE_USER ? 'user' : 'group'). ')'); ?>
 		<span class="shareactions">
-			<input class="update" type="checkbox" <?php p(($sharee['permissions'] & OCP\PERMISSION_UPDATE?'checked="checked"':''))?>
-				title="<?php p($l->t('Editable')); ?>">
-			<input class="share" type="checkbox" <?php p(($sharee['permissions'] & OCP\PERMISSION_SHARE?'checked="checked"':''))?>
-				title="<?php p($l->t('Shareable')); ?>">
-			<input class="delete" type="checkbox" <?php p(($sharee['permissions'] & OCP\PERMISSION_DELETE?'checked="checked"':''))?>
-				title="<?php p($l->t('Deletable')); ?>">
+			<label>
+				<input class="update" type="checkbox" <?php p(($sharee['permissions'] & OCP\PERMISSION_UPDATE?'checked="checked"':''))?>>
+				<?php p($l->t('can edit')); ?>
+			</label>
+			<label>
+				<input class="share" type="checkbox" <?php p(($sharee['permissions'] & OCP\PERMISSION_SHARE?'checked="checked"':''))?>>
+				<?php p($l->t('can share')); ?>
+			</label>
+			<label>
+				<input class="delete" type="checkbox" <?php p(($sharee['permissions'] & OCP\PERMISSION_DELETE?'checked="checked"':''))?>>
+				<?php p($l->t('can delete')); ?>
+			</label>
 			<img src="<?php p(OCP\Util::imagePath('core', 'actions/delete.svg')); ?>" class="svg action delete"
 				title="<?php p($l->t('Unshare')); ?>">
 		</span>
@@ -72,12 +78,18 @@ if(is_array($sharedwithByEvent)) {
 		data-share-type="<?php p($sharee['share_type']); ?>">
 		<?php p($sharee['share_with'] . ' (' . ($sharee['share_type'] == OCP\Share::SHARE_TYPE_USER ? 'user' : 'group'). ')'); ?>
 		<span class="shareactions">
-			<input class="update" type="checkbox" <?php p(($sharee['permissions'] & OCP\PERMISSION_UPDATE?'checked="checked"':''))?>
-				title="<?php p($l->t('Editable')); ?>">
-			<input class="share" type="checkbox" <?php p(($sharee['permissions'] & OCP\PERMISSION_SHARE?'checked="checked"':''))?>
-				title="<?php p($l->t('Shareable')); ?>">
-			<input class="delete" type="checkbox" <?php p(($sharee['permissions'] & OCP\PERMISSION_DELETE?'checked="checked"':''))?>
-				title="<?php p($l->t('Deletable')); ?>">
+			<label>
+				<input class="update" type="checkbox" <?php p(($sharee['permissions'] & OCP\PERMISSION_UPDATE?'checked="checked"':''))?>>
+				<?php p($l->t('can edit')); ?>
+			</label>
+			<label>
+				<input class="share" type="checkbox" <?php p(($sharee['permissions'] & OCP\PERMISSION_SHARE?'checked="checked"':''))?>>
+				<?php p($l->t('can share')); ?>
+			</label>
+			<label>
+				<input class="delete" type="checkbox" <?php p(($sharee['permissions'] & OCP\PERMISSION_DELETE?'checked="checked"':''))?>>
+				<?php p($l->t('can delete')); ?>
+			</label>
 			<img src="<?php p(OCP\Util::imagePath('core', 'actions/delete.svg')); ?>" class="svg action delete"
 				title="<?php p($l->t('Unshare')); ?>">
 		</span>


### PR DESCRIPTION
A lot of fixes … cc @owncloud/designers @georgehrke 
- simplified the event detail view to focus on title and time
- fixed some layout issues cc @mbiebl, fix https://github.com/owncloud/apps/issues/1482
- remove superfluous tipsy popup which just repeated obvious info
- remove scrolling to switch moth which made the calendar unusable with lots of events, fix #24, fix https://github.com/owncloud/apps/issues/771
- make event detail view and settings view scrollable, fix #81
- color weekend, don’t bold weekday names, lighter border color
- display full share permissions in share tab
- disable half-baked list view, change for proper day view, fix #80 
- fix access class wording, fix #113 
- remove superfluous 'Active' checkbox in edit calendar view
- lots more details

Would be cool if someone of you can fix #185 (loading feedback not visible). That I couldn’t manage.
