### PR TITLE
More calendar fixes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -218,6 +218,12 @@ button.category{margin:0 3px;}
 	overflow-x: hidden;
 }
 
+/* fix share dropdown being hidden and hiding calendar which will be shared */
+#appsettings_popup #dropdown {
+	left: 0;
+	margin-top: 20px;
+}
+
 /* color weekends */
 .fc-sat, .fc-sun {
 	background-color: #f8f8f8;

--- a/css/style.css
+++ b/css/style.css
@@ -64,7 +64,32 @@ button.category{margin:0 3px;}
 	margin: -5px 0 5px;
 }
 
-.sharedby li .shareactions { float: right; }
+
+
+#sharewith {
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
+	width: 100%;
+	margin: 5px 0 10px;
+}
+
+.sharedby li {
+	padding: 7px 0;
+}
+.sharedby .shareactions {
+	float: right;
+	clear: both;
+}
+.sharedby .shareactions label {
+	padding: 9px 5px;
+}
+.sharedby .shareactions input {
+	vertical-align: middle;
+}
+.sharedby .shareactions .delete {
+	float: right;
+	padding: 3px;
+}
 
 .fc-state-highlight { background: #ffa; }
 

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -577,7 +577,6 @@ Calendar={
 								+ '<span class="shareactions">'
 								+ '<label><input class="update" type="checkbox" checked="checked">'+t('core', 'can edit')+'</label>'
 								+ '<label><input class="share" type="checkbox" checked="checked">'+t('core', 'can share')+'</label>'
-								+ '<label><input class="delete" type="checkbox" checked="checked">'+t('core', 'can delete')+'</label>'
 								+ '<img class="svg action delete" title="Unshare"src="'+ OC.imagePath('core', 'actions/delete.svg') +'"></span></li>';
 							$('.sharedby.eventlist').append(newitem);
 							$('#sharedWithNobody').remove();
@@ -597,10 +596,9 @@ Calendar={
 						var permission = null;
 						if($(this).hasClass('update')) {
 							permission = OC.PERMISSION_UPDATE;
+							permission = OC.PERMISSION_DELETE;
 						} else if($(this).hasClass('share')) {
 							permission = OC.PERMISSION_SHARE;
-						} else if($(this).hasClass('delete')) {
-							permission = OC.PERMISSION_DELETE;
 						}
 						// This is probably not the right way, but it works :-P
 						if($(this).is(':checked')) {

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -571,7 +571,9 @@ Calendar={
 							var newitem = '<li data-item-type="event"'
 								+ 'data-share-with="'+shareWith+'" '
 								+ 'data-permissions="'+permissions+'" '
-								+ 'data-share-type="'+shareType+'">'+shareWith+' ('+(shareType == OC.Share.SHARE_TYPE_USER ? t('core', 'user') : t('core', 'group'))+')'
+								+ 'data-share-type="'+shareType+'">'
+								+ shareWith
+								+ (shareType === OC.Share.SHARE_TYPE_GROUP ? ' ('+t('core', 'group')+')' : '')
 								+ '<span class="shareactions"><label><input class="update" type="checkbox" checked="checked">'+t('core', 'can edit')+'</label>'
 								+ '<input class="share" type="checkbox" checked="checked">'+t('core', 'can share')+'</label>'
 								+ '<input class="delete" type="checkbox" checked="checked">'+t('core', 'can delete')+'</label>'

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -574,9 +574,10 @@ Calendar={
 								+ 'data-share-type="'+shareType+'">'
 								+ shareWith
 								+ (shareType === OC.Share.SHARE_TYPE_GROUP ? ' ('+t('core', 'group')+')' : '')
-								+ '<span class="shareactions"><label><input class="update" type="checkbox" checked="checked">'+t('core', 'can edit')+'</label>'
-								+ '<input class="share" type="checkbox" checked="checked">'+t('core', 'can share')+'</label>'
-								+ '<input class="delete" type="checkbox" checked="checked">'+t('core', 'can delete')+'</label>'
+								+ '<span class="shareactions">'
+								+ '<label><input class="update" type="checkbox" checked="checked">'+t('core', 'can edit')+'</label>'
+								+ '<label><input class="share" type="checkbox" checked="checked">'+t('core', 'can share')+'</label>'
+								+ '<label><input class="delete" type="checkbox" checked="checked">'+t('core', 'can delete')+'</label>'
 								+ '<img class="svg action delete" title="Unshare"src="'+ OC.imagePath('core', 'actions/delete.svg') +'"></span></li>';
 							$('.sharedby.eventlist').append(newitem);
 							$('#sharedWithNobody').remove();

--- a/templates/part.share.php
+++ b/templates/part.share.php
@@ -49,10 +49,6 @@ if(is_array($sharedwithByEvent)) {
 				<input class="share" type="checkbox" <?php p(($sharee['permissions'] & OCP\PERMISSION_SHARE?'checked="checked"':''))?>>
 				 <?php p($l->t('can share')); ?>
 			</label>
-			<label>
-				<input class="delete" type="checkbox" <?php p(($sharee['permissions'] & OCP\PERMISSION_DELETE?'checked="checked"':''))?>>
-				 <?php p($l->t('can delete')); ?>
-			</label>
 			<img src="<?php p(OCP\Util::imagePath('core', 'actions/delete.svg')); ?>" class="svg action delete"
 				title="<?php p($l->t('Unshare')); ?>">
 		</span>
@@ -89,12 +85,6 @@ if(is_array($sharedwithByEvent)) {
 					<?php p(($sharee['permissions'] & OCP\PERMISSION_SHARE?'checked="checked"':''))?>
 					disabled="disabled">
 				<?php p($l->t('can share')); ?>
-			</label>
-			<label>
-				<input class="delete" type="checkbox"
-					<?php p(($sharee['permissions'] & OCP\PERMISSION_DELETE?'checked="checked"':''))?>
-					disabled="disabled">
-				<?php p($l->t('can delete')); ?>
 			</label>
 		</span>
 	</li>

--- a/templates/part.share.php
+++ b/templates/part.share.php
@@ -60,7 +60,7 @@ if(is_array($sharedwithByEvent)) {
 <?php endforeach; ?>
 </ul>
 <?php if(!$eventsharees) {
-	$nobody = $l->t('Nobody');
+	$nobody = $l->t('Not shared with anyone');
 	print_unescaped('<div id="sharedWithNobody">' . OC_Util::sanitizeHTML($nobody) . '</div>');
 } ?>
 <br />
@@ -96,5 +96,9 @@ if(is_array($sharedwithByEvent)) {
 	</li>
 <?php endforeach; ?>
 </ul>
+<?php if(!$calsharees) {
+	$nobody = $l->t('Not shared with anyone via calendar');
+	print_unescaped('<div>' . OC_Util::sanitizeHTML($nobody) . '</div>');
+} ?>
 <br />
 <?php p($l->t('NOTE: Actions on events shared via calendar will affect the entire calendar sharing.')); ?>

--- a/templates/part.share.php
+++ b/templates/part.share.php
@@ -79,19 +79,23 @@ if(is_array($sharedwithByEvent)) {
 		<?php p($sharee['share_with'] . ' (' . ($sharee['share_type'] == OCP\Share::SHARE_TYPE_USER ? 'user' : 'group'). ')'); ?>
 		<span class="shareactions">
 			<label>
-				<input class="update" type="checkbox" <?php p(($sharee['permissions'] & OCP\PERMISSION_UPDATE?'checked="checked"':''))?>>
+				<input class="update" type="checkbox"
+					<?php p(($sharee['permissions'] & OCP\PERMISSION_UPDATE?'checked="checked"':''))?>
+					disabled="disabled">
 				<?php p($l->t('can edit')); ?>
 			</label>
 			<label>
-				<input class="share" type="checkbox" <?php p(($sharee['permissions'] & OCP\PERMISSION_SHARE?'checked="checked"':''))?>>
+				<input class="share" type="checkbox"
+					<?php p(($sharee['permissions'] & OCP\PERMISSION_SHARE?'checked="checked"':''))?>
+					disabled="disabled">
 				<?php p($l->t('can share')); ?>
 			</label>
 			<label>
-				<input class="delete" type="checkbox" <?php p(($sharee['permissions'] & OCP\PERMISSION_DELETE?'checked="checked"':''))?>>
+				<input class="delete" type="checkbox"
+					<?php p(($sharee['permissions'] & OCP\PERMISSION_DELETE?'checked="checked"':''))?>
+					disabled="disabled">
 				<?php p($l->t('can delete')); ?>
 			</label>
-			<img src="<?php p(OCP\Util::imagePath('core', 'actions/delete.svg')); ?>" class="svg action delete"
-				title="<?php p($l->t('Unshare')); ?>">
 		</span>
 	</li>
 <?php endforeach; ?>
@@ -100,5 +104,3 @@ if(is_array($sharedwithByEvent)) {
 	$nobody = $l->t('Not shared with anyone via calendar');
 	print_unescaped('<div>' . OC_Util::sanitizeHTML($nobody) . '</div>');
 } ?>
-<br />
-<?php p($l->t('NOTE: Actions on events shared via calendar will affect the entire calendar sharing.')); ?>

--- a/templates/part.share.php
+++ b/templates/part.share.php
@@ -39,7 +39,7 @@ if(is_array($sharedwithByEvent)) {
 		data-item-type="event"
 		data-permissions="<?php p($sharee['permissions']); ?>"
 		data-share-type="<?php p($sharee['share_type']); ?>">
-		<?php p($sharee['share_with'] . ' (' . ($sharee['share_type'] == OCP\Share::SHARE_TYPE_USER ? 'user' : 'group'). ')'); ?>
+		<?php p($sharee['share_with'] . ($sharee['share_type'] == OCP\Share::SHARE_TYPE_GROUP ? ' (group)' : '')); ?>
 		<span class="shareactions">
 			<label>
 				<input class="update" type="checkbox" <?php p(($sharee['permissions'] & OCP\PERMISSION_UPDATE?'checked="checked"':''))?>>
@@ -76,7 +76,7 @@ if(is_array($sharedwithByEvent)) {
 		data-item-type="calendar"
 		data-permissions="<?php p($sharee['permissions']); ?>"
 		data-share-type="<?php p($sharee['share_type']); ?>">
-		<?php p($sharee['share_with'] . ' (' . ($sharee['share_type'] == OCP\Share::SHARE_TYPE_USER ? 'user' : 'group'). ')'); ?>
+		<?php p($sharee['share_with'] . ($sharee['share_type'] == OCP\Share::SHARE_TYPE_GROUP ? ' (group)' : '')); ?>
 		<span class="shareactions">
 			<label>
 				<input class="update" type="checkbox"

--- a/templates/part.share.php
+++ b/templates/part.share.php
@@ -28,10 +28,10 @@ if(is_array($sharedwithByEvent)) {
 }
 ?>
 
-<label for="sharewith"><?php p($l->t('Share with:')); ?></label>
-<input type="text" id="sharewith" data-item-source="<?php p($eventid); ?>" /><br />
+<input type="text" id="sharewith"
+	placeholder="<?php p($l->t('Share with user or group')); ?>"
+	data-item-source="<?php p($eventid); ?>" />
 
-<strong><?php p($l->t('Shared with')); ?></strong>
 <ul class="sharedby eventlist">
 <?php foreach($eventsharees as $sharee): ?>
 	<li data-share-with="<?php p($sharee['share_with']); ?>"
@@ -43,15 +43,15 @@ if(is_array($sharedwithByEvent)) {
 		<span class="shareactions">
 			<label>
 				<input class="update" type="checkbox" <?php p(($sharee['permissions'] & OCP\PERMISSION_UPDATE?'checked="checked"':''))?>>
-				<?php p($l->t('can edit')); ?>
+				 <?php p($l->t('can edit')); ?>
 			</label>
 			<label>
 				<input class="share" type="checkbox" <?php p(($sharee['permissions'] & OCP\PERMISSION_SHARE?'checked="checked"':''))?>>
-				<?php p($l->t('can share')); ?>
+				 <?php p($l->t('can share')); ?>
 			</label>
 			<label>
 				<input class="delete" type="checkbox" <?php p(($sharee['permissions'] & OCP\PERMISSION_DELETE?'checked="checked"':''))?>>
-				<?php p($l->t('can delete')); ?>
+				 <?php p($l->t('can delete')); ?>
 			</label>
 			<img src="<?php p(OCP\Util::imagePath('core', 'actions/delete.svg')); ?>" class="svg action delete"
 				title="<?php p($l->t('Unshare')); ?>">


### PR DESCRIPTION
- clarify non-shared message, also add for shared via calendar
- fix share dropdown being hidden and hiding calendar which will be shared
- remove confusing note, instead only make it possible to edit calendar sharing settings in the calendar settings cc @te-online
- only append (group) indicator to groups, no need to put (user) after every user
- improve look of sharing tab
- remove 'can delete' permission, also resolve CSS 'delete' class conflict cc @DeepDiver1975 @georgehrke 

Please review @georgehrke @owncloud/designers – Georg, I’m not sure if I did the removal of »can delete« correctly.
