### PR TITLE
OC 6.0.0a - Fixed graphic glitch in "edit event" form

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -195,6 +195,7 @@ button.category{margin:0 3px;}
 }
 #fromtime, #totime {
 	margin: 0;
+	width: 60px;
 }
 #event-allday {
 	display: inline-block;

--- a/css/style.css
+++ b/css/style.css
@@ -200,6 +200,7 @@ button.category{margin:0 3px;}
 #event-allday {
 	display: inline-block;
 	margin: 7px 0;
+	width: 100%;
 }
 /* category input field leaves room for edit button */
 #category {

--- a/css/style.css
+++ b/css/style.css
@@ -195,7 +195,7 @@ button.category{margin:0 3px;}
 }
 #fromtime, #totime {
 	margin: 0;
-	width: 60px;
+	width: 80px;
 }
 #event-allday {
 	display: inline-block;


### PR DESCRIPTION
Added width to #fromtime and #totime classes in order to avoid a grapic glitch on "edit event" form in calendar (see screenshot for details)

![calendar-glitch](https://f.cloud.github.com/assets/1663025/1754287/75cfd916-664d-11e3-9f2b-3292b9ac049f.jpg)
