### PR TITLE
Shared-event permissions editing fix

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -703,6 +703,7 @@ Calendar={
 		Share:{
 			init:function(){
 				if(typeof OC.Share !== typeof undefined){
+					self = this;
 					var itemShares = [OC.Share.SHARE_TYPE_USER, OC.Share.SHARE_TYPE_GROUP];
 					$('#sharewith').autocomplete({minLength: 1, source: function(search, response) {
 						$.get(OC.filePath('core', 'ajax', 'share.php'), { fetch: 'getShareWith', search: search.term, itemShares: itemShares }, function(result) {
@@ -726,58 +727,63 @@ Calendar={
 							var newitem = '<li data-item-type="event"'
 								+ 'data-share-with="'+shareWith+'" '
 								+ 'data-permissions="'+permissions+'" '
+								+ 'data-item="'+itemSource+'" '
 								+ 'data-share-type="'+shareType+'">'
 								+ shareWith
 								+ (shareType === OC.Share.SHARE_TYPE_GROUP ? ' ('+t('core', 'group')+')' : '')
 								+ '<span class="shareactions">'
-								+ '<label><input class="update" type="checkbox" checked="checked">'+t('core', 'can edit')+'</label>'
+								+ '<label><input class="update" type="checkbox">'+t('core', 'can edit')+'</label>'
 								+ '<label><input class="share" type="checkbox" checked="checked">'+t('core', 'can share')+'</label>'
 								+ '<img class="svg action delete" title="Unshare"src="'+ OC.imagePath('core', 'actions/delete.svg') +'"></span></li>';
 							$('.sharedby.eventlist').append(newitem);
+							var appendeditem = $('.sharedby.eventlist li[data-share-with="'+shareWith+'"][data-share-type="'+shareType+'"]');
+							self.bindShareActionHandlers(appendeditem);
 							$('#sharedWithNobody').remove();
 							$('#sharewith').val('');
 						});
 						return false;
 					}
 					});
-	
-					$('.shareactions > input:checkbox').change(function() {
-						var container = $(this).parents('li').first();
-						var permissions = parseInt(container.data('permissions'));
-						var itemType = container.data('item-type');
-						var shareType = container.data('share-type');
-						var itemSource = container.data('item');
-						var shareWith = container.data('share-with');
-						var permission = null;
-						if($(this).hasClass('update')) {
-							permission = OC.PERMISSION_UPDATE;
-							permission = OC.PERMISSION_DELETE;
-						} else if($(this).hasClass('share')) {
-							permission = OC.PERMISSION_SHARE;
-						}
-						// This is probably not the right way, but it works :-P
-						if($(this).is(':checked')) {
-							permissions += permission;
-						} else {
-							permissions -= permission;
-						}
-						
-						container.data('permissions',permissions);
-						
-						OC.Share.setPermissions(itemType, itemSource, shareType, shareWith, permissions);
-					});
-	
-					$('.shareactions > .delete').click(function() {
-						var container = $(this).parents('li').first();
-						var itemType = container.data('item-type');
-						var shareType = container.data('share-type');
-						var itemSource = container.data('item');
-						var shareWith = container.data('share-with');
-						OC.Share.unshare(itemType, itemSource, shareType, shareWith, function() {
-							container.remove();
-						});
-					});
+					self.bindShareActionHandlers();
 				}
+			},
+			bindShareActionHandlers:function(context){
+				$('.shareactions > label > input:checkbox', context).change(function() {
+					var container = $(this).parents('li').first();
+					var permissions = parseInt(container.data('permissions'));
+					var itemType = container.data('item-type');
+					var shareType = container.data('share-type');
+					var itemSource = container.data('item');
+					var shareWith = container.data('share-with');
+					var permission = null;
+					if($(this).hasClass('update')) {
+						permission = OC.PERMISSION_UPDATE;
+						permission = OC.PERMISSION_DELETE;
+					} else if($(this).hasClass('share')) {
+						permission = OC.PERMISSION_SHARE;
+					}
+					// This is probably not the right way, but it works :-P
+					if($(this).is(':checked')) {
+						permissions += permission;
+					} else {
+						permissions -= permission;
+					}
+	
+					container.data('permissions',permissions);
+
+					OC.Share.setPermissions(itemType, itemSource, shareType, shareWith, permissions);
+				});
+
+				$('.shareactions > .delete', context).click(function() {
+					var container = $(this).parents('li').first();
+					var itemType = container.data('item-type');
+					var shareType = container.data('share-type');
+					var itemSource = container.data('item');
+					var shareWith = container.data('share-with');
+					OC.Share.unshare(itemType, itemSource, shareType, shareWith, function() {
+						container.remove();
+					});
+				});
 			}
 		},
 		Drop:{

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -757,8 +757,7 @@ Calendar={
 					var shareWith = container.data('share-with');
 					var permission = null;
 					if($(this).hasClass('update')) {
-						permission = OC.PERMISSION_UPDATE;
-						permission = OC.PERMISSION_DELETE;
+						permission = OC.PERMISSION_UPDATE | OC.PERMISSION_DELETE;
 					} else if($(this).hasClass('share')) {
 						permission = OC.PERMISSION_SHARE;
 					}

--- a/templates/part.share.php
+++ b/templates/part.share.php
@@ -42,7 +42,7 @@ if(is_array($sharedwithByEvent)) {
 		<?php p($sharee['share_with'] . ($sharee['share_type'] == OCP\Share::SHARE_TYPE_GROUP ? ' (group)' : '')); ?>
 		<span class="shareactions">
 			<label>
-				<input class="update" type="checkbox" <?php p(($sharee['permissions'] & OCP\PERMISSION_UPDATE?'checked="checked"':''))?>>
+				<input class="update" type="checkbox" <?php p(($sharee['permissions'] & (OCP\PERMISSION_UPDATE | OCP\PERMISSION_DELETE)?'checked="checked"':''))?>>
 				 <?php p($l->t('can edit')); ?>
 			</label>
 			<label>


### PR DESCRIPTION
Hi there,

I've been looking into solving a few issues for Owncloud's calendar app over the last few days, and this is my first fix.

The changes in this commit allow edit/reshare-permissions to be saved for shared events, which solves: https://github.com/owncloud/calendar/issues/217 and https://github.com/owncloud/calendar/issues/263 (which appears to be a duplicate).

As suggested in https://github.com/owncloud/calendar/issues/217#issuecomment-28973489, I have altered permissions checking in lib/object.php so that users who only have update permissions for a single event (but not for the whole calendar) are able to edit the event. However, perhaps OC_Calendar_App::getPermissions() should be used instead to check event/calendar permissions in lib/object.php?

One problem that has not been addressed is that shared-event 'resharing' permissions always override shared-calendar 'resharing' permissions.
So in the rare case that a user has reshare-permissions for a shared-calendar, but not for a shared-event on that calendar, they will be denied access if they attempt to reshare that event.
This problem seems to be with the permissions-checking in OCP\Share::put().

Please let me know if I haven't made anything clear or if you would like me to make any changes, and thanks for all your hard work on Owncloud :)

Cheers,
Ben
