### PR TITLE
Event title is no longer selected after being focused.

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -136,6 +136,9 @@ Calendar={
 			$('#sendemailbutton').click(function() {
 				Calendar.Util.sendmail($(this).attr('data-eventid'), $(this).attr('data-location'), $(this).attr('data-description'), $(this).attr('data-dtstart'), $(this).attr('data-dtend'));
 			})
+			// Focus the title, and reset the text value so that it isn't selected.
+			var val = $('#event-title').val();
+			$('#event-title').focus().val('').val(val);
 		},
 		newEvent:function(start, end, allday){
 			start = Math.round(start.getTime()/1000);


### PR DESCRIPTION
This fix for https://github.com/owncloud/calendar/issues/224 will make sure that the event title is focused (but not selected) when the event dialog is opened.
Solution based on: http://stackoverflow.com/a/12892564
