### PR TITLE
Month table no longer jumps when the event dialog is opened

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -14,6 +14,7 @@
 #newentry_dialog {display: none;}
 #editentry_dialog {display: none;}
 #parsingfail_dialog{display: none;}
+#dialog_holder {display: none;}
 
 #loading { display: none;margin: 0;padding:0;margin-top:5px;}
 


### PR DESCRIPTION
This fix for https://github.com/owncloud/calendar/issues/222 hides the dialog_holder so that its height doesn't increase when a dialog is loaded into it, which was causing the month table to jump as described in the issue.
