### PR TITLE
Fixed display names for access classes

### DIFF
--- a/lib/object.php
+++ b/lib/object.php
@@ -529,8 +529,8 @@ class OC_Calendar_Object{
 	public static function getAccessClassOptions($l10n) {
 		return array(
 			'PUBLIC'       => (string)$l10n->t('Show full event'),
-			'PRIVATE'      => (string)$l10n->t('Show only busy'),
-			'CONFIDENTIAL' => (string)$l10n->t('Hide event')
+			'CONFIDENTIAL' => (string)$l10n->t('Show only busy'),
+			'PRIVATE'      => (string)$l10n->t('Hide event')
 		);
 	}
 


### PR DESCRIPTION
This should fix at least part of https://github.com/owncloud/calendar/issues/258
It seems that the display names for the PRIVATE and CONFIDENTIAL access classes were reversed.

Perhaps CONFIDENTIAL should be renamed to better indicate a "Show only busy" state, as the meanings of CONFIDENTIAL and PRIVATE seem to be easily confusable?
