### PR TITLE
Fixed share-icon overlapping glitch

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -264,3 +264,11 @@ button.category{margin:0 3px;}
 .fc-widget-header, .fc-widget-content {
 	border: 1px solid #e8e8e8;
 }
+
+#calendar td a.share {
+	display: block;
+	width: 20px;
+	height: 20px;
+	background-repeat: no-repeat;
+	background-position: center;
+}

--- a/templates/part.choosecalendar.rowfields.php
+++ b/templates/part.choosecalendar.rowfields.php
@@ -10,7 +10,7 @@
   <?php if($_['calendar']['permissions'] & OCP\PERMISSION_SHARE) { ?>
   <a href="#" class="share" data-item-type="calendar" data-item="<?php p($_['calendar']['id']); ?>"
 	data-possible-permissions="<?php p($_['calendar']['permissions']) ?>"
-	title="<?php p($l->t('Share Calendar')) ?>" class="action permanent"><img class="svg" src="<?php print_unescaped((!$_['shared']) ? OCP\Util::imagePath('core', 'actions/share.svg') : OCP\Util::imagePath('core', 'actions/shared.svg')) ?>"></a>
+	title="<?php p($l->t('Share Calendar')) ?>" class="action permanent" style="background-image: url(<?php print_unescaped((!$_['shared']) ? OCP\Util::imagePath('core', 'actions/share.svg') : OCP\Util::imagePath('core', 'actions/shared.svg')) ?>);"></a>
   <?php } ?>
 </td>
 <td width="20px">


### PR DESCRIPTION
Fix for https://github.com/owncloud/calendar/issues/119 that uses background images instead of img elements for share icons, so that icons are replaced (instead of overlapped) when OC.Share.updateIcons() is called.
