### PR TITLE
Fix non ascii character display on calendar share dialog

### DIFF
--- a/templates/settings.php
+++ b/templates/settings.php
@@ -123,7 +123,7 @@
 				$uri = rawurlencode(html_entity_decode($calendar['uri'], ENT_QUOTES, 'UTF-8')) . '_shared_by_' . $calendar['userid'];
 			}
 			?>
-			<a href="<?php p(OCP\Util::linkToRemote('caldav').'calendars/'.OCP\USER::getUser().'/'.$uri) ?>?export" class="link"><?php p(OCP\Util::sanitizeHTML($calendar['displayname'])) ?></a><br />
+			<a href="<?php p(OCP\Util::linkToRemote('caldav').'calendars/'.OCP\USER::getUser().'/'.$uri) ?>?export" class="link"><?php p($calendar['displayname']) ?></a><br />
 			<?php } ?>
 		</dd>
 		</dl>


### PR DESCRIPTION
Before, sanitizeHTML for displaying the name of the calendar was being
encoded. This was causing non-ascii characters to be shown strange.
This should fix this problem. Since this is only a display text,
sanitizing should not be a problem.
