### PR TITLE
Event sharing fixes

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -448,6 +448,14 @@ Calendar={
 					}
 				  });
 			},
+			sharedEventsActivation:function(checkbox)
+			{
+				if (checkbox.checked){
+					$('#fullcalendar').fullCalendar('addEventSource', sharedEventSource);
+				}else{
+					$('#fullcalendar').fullCalendar('removeEventSource', sharedEventSource.url);
+				}
+			},
 			newCalendar:function(object){
 				var tr = $(document.createElement('tr'))
 					.load(OC.filePath('calendar', 'ajax/calendar', 'new.form.php'),
@@ -956,4 +964,10 @@ $(document).ready(function(){
 		OC.appSettings({appid:'calendar', loadJS:true, cache:false, scriptName:'settingswrapper.php'});
 	});
 	$('#fullcalendar').fullCalendar('option', 'height', $(window).height() - $('#controls').height() - $('#header').height() - 15);
+	// Save the eventSource for shared events.
+	for (var i in eventSources) {
+		if (eventSources[i].url.substr(-13) === 'shared_events') {
+			sharedEventSource = eventSources[i];
+		}
+	}
 });

--- a/js/on-event.js
+++ b/js/on-event.js
@@ -28,6 +28,9 @@ $('#chooseCalendar').live('click', function () {
 $('.activeCalendar').live('change', function () {
 	Calendar.UI.Calendar.activation(this,$(this).data('id'));
 });
+$('#active_shared_events').live('change', function () {
+	Calendar.UI.Calendar.sharedEventsActivation(this);
+});
 $('#allday_checkbox').live('click', function () {
 	Calendar.UI.lockTime();
 });

--- a/lib/app.php
+++ b/lib/app.php
@@ -407,7 +407,19 @@ class OC_Calendar_App{
 		$events = array();
 		if($calendarid == 'shared_events') {
 			$singleevents = OCP\Share::getItemsSharedWith('event', OC_Share_Backend_Event::FORMAT_EVENT);
+			$calendars = OC_Calendar_Calendar::allCalendars(OCP\USER::getUser());
 			foreach($singleevents as $singleevent) {
+				// Skip this single event if the whole calendar is already shared with the user.
+				$calendarShared = false;
+				foreach ($calendars as $calendar) {
+					if ($singleevent['calendarid'] === $calendar['id']) {
+						$calendarShared = true;
+						break;
+					}
+				}
+				if ($calendarShared === true) {
+					continue;
+				}
 				$singleevent['summary'] .= ' (' . self::$l10n->t('by') .  ' ' . OC_Calendar_Object::getowner($singleevent['id']) . ')';
 				$events[] =  $singleevent;
 			}

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -19,6 +19,14 @@
 	}
 	?>
 	<tr>
+		<td width="20px">
+			<input type="checkbox" id="active_shared_events" data-id="shared_events" checked="checked">
+		</td>
+		<td id="<?php p(OCP\USER::getUser()) ?>_shared_events">
+			<label for="active_shared_events"><?php p($l->t('Shared events')) ?></label>
+		</td>
+	</tr>
+	<tr>
 		<td colspan="6">
 			<input type="button" value="<?php p($l->t('New Calendar')) ?>" id="newCalendar">
 		</td>


### PR DESCRIPTION
A couple of fixes related to individually shared events:
- When retrieving a list of events that have been shared with a user: events that belong to calendars that the user can access are ignored. This prevents events from being shown twice on the calendar view.
- A new "Shared events" calendar is displayed in the list of calendars. This calendar allows users to hide/show all events that have been individually shared with them. This solves the problem of someone individually sharing 100 spam events with you, and you having no way to hide them.
