### PR TITLE
Calendar shared with owner - duplicate calendar fix

### DIFF
--- a/lib/calendar.php
+++ b/lib/calendar.php
@@ -46,13 +46,24 @@ class OC_Calendar_Calendar{
 		$result = $stmt->execute($values);
 
 		$calendars = array();
+		$owned_calendar_ids = array();
 		while( $row = $result->fetchRow()) {
 			$row['permissions'] = OCP\PERMISSION_CREATE
 				| OCP\PERMISSION_READ | OCP\PERMISSION_UPDATE
 				| OCP\PERMISSION_DELETE | OCP\PERMISSION_SHARE;
 			$calendars[] = $row;
+			$owned_calendar_ids[] = $row['id'];
 		}
-		$calendars = array_merge($calendars, OCP\Share::getItemsSharedWith('calendar', OC_Share_Backend_Calendar::FORMAT_CALENDAR));
+
+		$shared_calendars = OCP\Share::getItemsSharedWith('calendar', OC_Share_Backend_Calendar::FORMAT_CALENDAR);
+		// Remove shared calendars that are already owned by the user.
+		foreach ($shared_calendars as $key => $calendar) {
+			if (in_array($calendar['id'], $owned_calendar_ids)) {
+				unset($shared_calendars[$key]);
+			}
+		}
+
+		$calendars = array_merge($calendars, $shared_calendars);
 
 		return $calendars;
 	}


### PR DESCRIPTION
If a user owns a calendar that is also shared with them (e.g. by user1 sharing their calendar with user2, user2 sharing with user3, and user3 sharing with user1 again), the calendar is no longer duplicated in the list returned by OC_Calendar_Calendar::allCalendars() for the user.
