### PR TITLE
remove possibility to overwrite on import

### DIFF
--- a/js/loader.js
+++ b/js/loader.js
@@ -124,7 +124,6 @@ Calendar_Import={
 				$('#calendar_import_process').css('display', 'block');
 				$('#calendar_import_newcalendar').attr('readonly', 'readonly');
 				$('#calendar_import_calendar').attr('disabled', 'disabled');
-				$('#calendar_import_overwrite').attr('disabled', 'disabled');
 				Calendar_Import.Core.send();
 				window.setTimeout('Calendar_Import.Dialog.update()', 250);
 			}
@@ -159,7 +158,6 @@ Calendar_Import={
 				}
 			}else{
 				Calendar_Import.Store.method = 'old';
-				Calendar_Import.Store.overwrite = $('#calendar_import_overwrite').is(':checked') ? 1 : 0;
 			}
 			return true;
 		}

--- a/templates/part.import.php
+++ b/templates/part.import.php
@@ -44,8 +44,6 @@ $defaultcolors = OC_Calendar_Calendar::getCalendarColorOptions();
 			<!--<input id="calendar_import_generatename" type="button" class="button" value="<?php p($l->t('Take an available name!')); ?>"><br>-->
 			<div  id="calendar_import_mergewarning" class="hint"><?php p($l->t('A Calendar with this name already exists. If you continue anyhow, these calendars will be merged.')); ?></div>
 		</div>
-		<input type="checkbox" id="calendar_import_overwrite" value="1">
-		<label for="calendar_import_overwrite"><?php p($l->t('Remove all events from the selected calendar')); ?></label>
 		<br>
 		<input id="calendar_import_submit" type="button" class="button" value="&raquo; <?php p($l->t('Import')); ?> &raquo;" id="startimport">
 	<form>


### PR DESCRIPTION
Every time I want to import an event, I get scared at the import form. This checkbox to potentially delete the whole calendar is just a bit too easy to click.

If you really want to overwrite the calendar, then you should delete it in the calendar app. No need for the dangerous »yeah sure destroy my data while doing other stuff« checkbox.

@georgehrke @jbtbnl please review. :) (There’s some other »overwrite« stuff in the code which is just at »0«, not sure if it should also be ripped out.)
