### PR TITLE
rename 'Default calendar' to more sensible 'Personal', 

### DIFF
--- a/lib/calendar.php
+++ b/lib/calendar.php
@@ -127,7 +127,7 @@ class OC_Calendar_Calendar{
 			$userid = OCP\USER::getUser();
 		}
 		
-		$id = self::addCalendar($userid,'Default calendar');
+		$id = self::addCalendar($userid,'Personal');
 
 		return true;
 	}


### PR DESCRIPTION
Thanks @jeffrobo, this fixes #203 

Please review @owncloud/designers @georgehrke 
