### PR TITLE
Allow only owner of calendar edit shared calendars

### DIFF
--- a/lib/calendar.php
+++ b/lib/calendar.php
@@ -182,9 +182,6 @@ class OC_Calendar_Calendar{
 	public static function editCalendar($id,$name=null,$components=null,$timezone=null,$order=null,$color=null) {
 		// Need these ones for checking uri
 		$calendar = self::find($id);
-		//if ($calendar['userid'] != OCP\User::getUser() && !OC_Group::inGroup(OCP\User::getUser(), 'admin')) {
-		//	$sharedCalendar = OCP\Share::getItemSharedWithBySource('calendar', $id);
-		//	if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\PERMISSION_UPDATE)) {
 		if ($calendar['userid'] != OCP\User::getUser())) {{
 				throw new Exception(
 					OC_Calendar_App::$l10n->t(

--- a/lib/calendar.php
+++ b/lib/calendar.php
@@ -182,7 +182,7 @@ class OC_Calendar_Calendar{
 	public static function editCalendar($id,$name=null,$components=null,$timezone=null,$order=null,$color=null) {
 		// Need these ones for checking uri
 		$calendar = self::find($id);
-		if ($calendar['userid'] != OCP\User::getUser())) {{
+		if ($calendar['userid'] != OCP\User::getUser()) {{
 				throw new Exception(
 					OC_Calendar_App::$l10n->t(
 						'You do not have the permissions to update this calendar.'

--- a/lib/calendar.php
+++ b/lib/calendar.php
@@ -182,9 +182,10 @@ class OC_Calendar_Calendar{
 	public static function editCalendar($id,$name=null,$components=null,$timezone=null,$order=null,$color=null) {
 		// Need these ones for checking uri
 		$calendar = self::find($id);
-		if ($calendar['userid'] != OCP\User::getUser() && !OC_Group::inGroup(OCP\User::getUser(), 'admin')) {
-			$sharedCalendar = OCP\Share::getItemSharedWithBySource('calendar', $id);
-			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\PERMISSION_UPDATE)) {
+		//if ($calendar['userid'] != OCP\User::getUser() && !OC_Group::inGroup(OCP\User::getUser(), 'admin')) {
+		//	$sharedCalendar = OCP\Share::getItemSharedWithBySource('calendar', $id);
+		//	if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\PERMISSION_UPDATE)) {
+		if ($calendar['userid'] != OCP\User::getUser())) {{
 				throw new Exception(
 					OC_Calendar_App::$l10n->t(
 						'You do not have the permissions to update this calendar.'


### PR DESCRIPTION
Currently there are two problems:
- if anyone edits (changes name or color) shared calendar, then changes are propagated to all users
- there is bug that if anyone edits calendar, calendar becomes deactivated. It's pretty bad, as only owner can activate calendar back and it also affects all users with access to calendar

This workaround is far from best option (everybody can activate/deactivate and change color of only own copy) but prevents users from destroying something what they can't fix
