### PR TITLE
Fix adding event dialog minor bug

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -161,6 +161,11 @@ Calendar={
 			$('#advanced_month').change(function(){
 				Calendar.UI.repeat('month');
 			});
+			$('#event-title').bind('keydown', function(event){
+				if (event.which == 13){
+					$('#event_form #submitNewEvent').click();
+				}
+			});
 			$( "#event" ).tabs({ selected: 0});
 			$('#event').dialog({
 				width : 500,

--- a/templates/part.eventform.php
+++ b/templates/part.eventform.php
@@ -70,7 +70,9 @@
 
 		<textarea id="event-description" placeholder="<?php p($l->t('Description'));?>" name="description"><?php p(isset($_['description']) ? $_['description'] : '') ?></textarea>
 
+		<?php if($_['eventid'] != 'new'){ ?>
 		<input type="button" class="submit" id="editEvent-export"  name="export" value="<?php p($l->t('Export event'));?>" data-link="<?php print_unescaped(OCP\Util::linkTo('calendar', 'export.php')) ?>?eventid=<?php p($_['eventid']) ?>">
+		<?php }?>
 	</div>
 </div>
 


### PR DESCRIPTION
Hi, the `Export event` button should not shown on new event dialog because export mechanism work with saved events in database. and currently when clicking on it, a 404 page displayed. So it must to be hidden on `Create new event` dialog.

Also I think it is good to trigger `Enter` button within event-title text-box so one can add event more quicker.
