### PR TITLE
Fix untranslatable strings

### DIFF
--- a/ajax/settings/guesstimezone.php
+++ b/ajax/settings/guesstimezone.php
@@ -23,5 +23,5 @@ if($timezone == OCP\Config::getUserValue(OCP\USER::getUser(), 'calendar', 'timez
 	exit;
 }
 OCP\Config::setUserValue(OCP\USER::getUser(), 'calendar', 'timezone', $timezone);
-$message = array('message'=> $l->t('New Timezone:') . $timezone);
+$message = array('message'=> $l->t('New Timezone:') . ' ' . $timezone);
 OCP\JSON::success($message);

--- a/lib/calendar.php
+++ b/lib/calendar.php
@@ -139,7 +139,7 @@ class OC_Calendar_Calendar{
 			$userid = OCP\USER::getUser();
 		}
 		
-		$id = self::addCalendar($userid,'Personal');
+		$id = self::addCalendar($userid,OC_Calendar_App::$l10n->t('Personal'));
 
 		return true;
 	}

--- a/templates/part.showevent.php
+++ b/templates/part.showevent.php
@@ -38,7 +38,7 @@
 			<td>
 			<?php
 			$calendar = OC_Calendar_App::getCalendar($_['calendar'], false, false);
-			p($calendar['displayname']) . ' ' . $l->t('of') . ' ' . $calendar['userid'];
+			p($l->t('%s of %s', array($calendar['displayname'], $calendar['userid'])));
 			?>
 			</td>
 			<th width="75px">&nbsp;</th>


### PR DESCRIPTION
- The default calendar name now can be translated
- Added a space between timezone and this will not affect
  existing translations
