### PR TITLE
Remove SanitizeHTML which encodes non-ascii characters while editing cal.

### DIFF
--- a/templates/part.editcalendar.php
+++ b/templates/part.editcalendar.php
@@ -8,7 +8,7 @@
 ?>
 <div id="<?php p($_['new'] ? 'new' : 'edit') ?>calendar_dialog" title="<?php p($_['new'] ? $l->t("New calendar") : $l->t("Edit calendar")); ?>" colspan="6">
 	<span>
-		<input id="displayname_<?php p($_['calendar']['id']) ?>" type="text" value="<?php p(OCP\Util::sanitizeHTML($_['calendar']['displayname'])) ?>">
+		<input id="displayname_<?php p($_['calendar']['id']) ?>" type="text" value="<?php print_unescaped($_['calendar']['displayname']) ?>">
 		<input id="editCalendar-submit" class="primary icon-checkmark-white" type="button" data-id="<?php p($_['new'] ? "new" : $_['calendar']['id']) ?>">
 	</span>
 	<select id="calendarcolor_<?php p($_['calendar']['id']) ?>" class="colorpicker">

--- a/templates/part.import.php
+++ b/templates/part.import.php
@@ -25,7 +25,7 @@ $defaultcolors = OC_Calendar_Calendar::getCalendarColorOptions();
 		<select style="width:100%;" id="calendar_import_calendar" name="calendar_import_calendar">
 		<?php
 		for($i = 0;$i<count($calendar_options);$i++) {
-			$calendar_options[$i]['displayname'] = OCP\Util::sanitizeHTML($calendar_options[$i]['displayname']);
+			$calendar_options[$i]['displayname'];
 		}
 		print_unescaped(OCP\html_select_options($calendar_options, $calendar_options[0]['id'], array('value'=>'id', 'label'=>'displayname')));
 		?>


### PR DESCRIPTION
- Create a calendar with a non-ascii character: eg. üçöğ
- Edit the calendar with edit link
- The characters are encoded and not possible to see them properly.

@georgehrke What do you think?
