### PR TITLE
Fix activation of shared calendars.

### DIFF
--- a/ajax/calendar/activation.php
+++ b/ajax/calendar/activation.php
@@ -12,7 +12,7 @@ OCP\JSON::checkAppEnabled('calendar');
 OCP\JSON::callCheck();
 
 $calendarid = $_POST['calendarid'];
-$calendar = OC_Calendar_App::getCalendar($calendarid, true);
+$calendar = OC_Calendar_App::getCalendar($calendarid, true, true);
 if(!$calendar) {
 	OCP\JSON::error(array('message'=>'permission denied'));
 	exit;
@@ -25,7 +25,7 @@ try {
 	exit;
 }
 
-$calendar = OC_Calendar_App::getCalendar($calendarid);
+$calendar = OC_Calendar_App::getCalendar($calendarid, true, true);
 OCP\JSON::success(array(
 	'active' => $calendar['active'],
 	'eventSource' => OC_Calendar_Calendar::getEventSourceInfo($calendar),

--- a/templates/part.choosecalendar.rowfields.php
+++ b/templates/part.choosecalendar.rowfields.php
@@ -3,7 +3,7 @@
 <label for="active_<?php p($_['calendar']['id']) ?>" class="calendarLabel">
 	<div class="calendarCheckbox<?php print_unescaped($_['calendar']['active'] ? '' : ' unchecked') ?>" id="checkbox_<?php p($_['calendar']['id']) ?>" style="background-color:<?php print_unescaped(($_['calendar']['calendarcolor']) ? $_['calendar']['calendarcolor'] : 'rgb(58, 135, 173)') ?>"></div>
 	<?php p($_['calendar']['displayname']) ?>
-	<?php if ($_['calendar']['userid'] == OCP\USER::getUser()) { ?>
+	<?php if ($_['calendar']['userid'] == OCP\USER::getUser() || (($sharedCalendar = OCP\Share::getItemSharedWithBySource('calendar', $_['calendar']['id'])) && ($sharedCalendar['permissions'] & OCP\PERMISSION_UPDATE))) { ?>
 		<input type="checkbox" id="active_<?php p($_['calendar']['id']) ?>" class="activeCalendar" data-id="<?php p($_['calendar']['id']) ?>" <?php print_unescaped($_['calendar']['active'] ? ' checked="checked"' : '') ?>>
 	<?php } ?>
 </label>


### PR DESCRIPTION
Editing shared calendars deactivates them and it is impossible to
activate them afterwards.

There are actually two problems:
- Shared calendars are deactivated when editing because they are
  missing their checkbox. Consequently, the checked status can not
  be read and the update function sets it to 0.
- As shared calendars do not have a checkbox, it is not possible to
  toggle their activation state afterwards.

This change adds a checkbox for shared calendars and allows their
activation, fixing both problems.
