### PR TITLE
Do not allow deleting shared calendars.

### DIFF
--- a/lib/calendar.php
+++ b/lib/calendar.php
@@ -252,7 +252,7 @@ class OC_Calendar_Calendar{
 	 * @param integer $id
 	 * @return boolean
 	 */
-	public static function deleteCalendar($id) {
+	public static function deleteCalendar($id, $force=false) {
 		$calendar = self::find($id);
 		$isShared = ($calendar['userid'] !== OCP\User::getUser());
 		if (!self::isAllowedToDeleteCalendar($calendar)) {
@@ -266,7 +266,7 @@ class OC_Calendar_Calendar{
 			}
 		}
 
-		if (!$isShared) {
+		if (!$isShared || $force) {
 			$stmt = OCP\DB::prepare( 'DELETE FROM `*PREFIX*clndr_calendars` WHERE `id` = ?' );
 			$stmt->execute(array($id));
 

--- a/lib/hooks.php
+++ b/lib/hooks.php
@@ -31,7 +31,7 @@ class OC_Calendar_Hooks{
 
 		foreach($calendars as $calendar) {
 			if($parameters['uid'] === $calendar['userid']) {
-				OC_Calendar_Calendar::deleteCalendar($calendar['id']);
+				OC_Calendar_Calendar::deleteCalendar($calendar['id'], true);
 			}
 		}
 


### PR DESCRIPTION
This pull request makes sure that shared calendars can not be deleted but are instead unshared.

This change depends on owncloud/core#9915.
