### PR TITLE
Prevent selection effect on accidental selection

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -36,6 +36,11 @@ body {
 	right: 0;
 	left: 0;
 	top: 0;
+
+	/* prevent ugly selection effect on accidental selection  */
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
 }
 #listview {margin: 0; padding: 10px; background: #EEEEEE;}
 #listview #more_before, #listview #more_after {border: 1px solid #1a1a1a; width:25em;padding: 3px;text-align: center;}
@@ -561,7 +566,7 @@ button.category{margin:0 3px;}
 	border: none;
 	border-top: 1px solid red;
 	width: 100%;
-	
+
 	z-index: 999;
 }
 


### PR DESCRIPTION
Prevent the light blue color (depends on the os) due to an accidental selection. Same fix as the one for the navbar.

Before :
![](https://kloug.pld.li/scr.png)

After : well, no blue color !
