### PR TITLE
Make VEVENT objects visible which don't have a DTEND field

### DIFF
--- a/lib/object.php
+++ b/lib/object.php
@@ -414,6 +414,10 @@ class OC_Calendar_Object{
 					$return[5] = $property->value;
 				}
 			}
+			// some imported object don't have DTEND but DURATION
+			if(is_null($return[2])) {
+				$return[2] = self::getDTEndFromVEvent($use);
+			}
 		}
 
 		// More than one child means reoccuring!


### PR DESCRIPTION
When importing VEVENT objects into ownCloud which don't have a DTEND field
but a DURATION field, the end of the event is not stored in the database and
thus the event is never shown to the user.

This patch calculates DTEND from DTSTART+DURATION in case DTEND isn't
available. This function (getDTEndFromVEvent) was already implemented, but not
used in this stage.

Applying this patch doesn't automatically reveal all events, but everything
imported after patching is handled correctly.

Example of an event which shows this problem:

```
BEGIN:VEVENT
DTSTART;TZID=Europe/Amsterdam:20141129T203000
SUMMARY:Test event
TRANSP:OPAQUE
DURATION:PT1H
LAST-MODIFIED:20141114T001747Z
CREATED:20141114T001747Z
DTSTAMP:20141114T001747Z
UID:d2573745-38b0-4480-af08-74ff38d745fd
CLASS:PUBLIC
BEGIN:VALARM
TRIGGER;VALUE=DURATION:-P7D
ACTION:DISPLAY
DESCRIPTION:Default Event Notification
X-WR-ALARMUID:bbfff3dc-f36c-49bd-b789-abd5d4b8b1e2
END:VALARM
END:VEVENT
```
