### PR TITLE
use OCP namespace, fix search

### DIFF
--- a/lib/search/event.php
+++ b/lib/search/event.php
@@ -23,7 +23,7 @@ namespace OCA\Calendar\Search;
 /**
  * A calendar event
  */
-class Event extends \OC\Search\Result {
+class Event extends \OCP\Search\Result {
 
 	/**
 	 * Type name; translated in templates

--- a/lib/search/provider.php
+++ b/lib/search/provider.php
@@ -23,7 +23,7 @@ namespace OCA\Calendar\Search;
 /**
  * The updated calendar search provider
  */
-class Provider extends \OC\Search\Provider {
+class Provider extends \OCP\Search\Provider {
 
 	/**
 	 * Search for query in calendar events


### PR DESCRIPTION
fixes `Fatal error: Class 'OC\Search\Provider' not found in /.../core/apps-repos/calendar/lib/search/provider.php on line 26`
