### PR TITLE
in oc8 or later share_backend need to implement isShareTypeAllowed()

### DIFF
--- a/lib/share/calendar.php
+++ b/lib/share/calendar.php
@@ -112,4 +112,8 @@ class OC_Share_Backend_Calendar implements OCP\Share_Backend_Collection {
 		return $children;
 	}
 
+	public function isShareTypeAllowed($shareType) {
+		return true;
+	}
+
 }

--- a/lib/share/event.php
+++ b/lib/share/event.php
@@ -45,4 +45,8 @@ class OC_Share_Backend_Event implements OCP\Share_Backend {
 		return $events;
 	}
 
+	public function isShareTypeAllowed($shareType) {
+		return true;
+	}
+
 }


### PR DESCRIPTION
share_backend was extended with isShareTypeAllowed here: https://github.com/owncloud/core/pull/12749

Will be needed after the PR on core was merged
