### PR TITLE
fix js and css loading for owncloud 8

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -40,7 +40,7 @@ Sabre\VObject\Property::$classMap['LOCATION'] = 'OC\VObject\StringProperty';
 
 $url = OC::$server->getRequest()->server['REQUEST_URI'];
 
-if (preg_match('%index.php/apps/files/?.*%', $url)) {
+if (preg_match('%index.php/apps/files(/.*)?%', $url)) {
     OCP\Util::addscript('calendar','loader');
     OCP\Util::addScript('calendar', '../3rdparty/chosen/js/chosen.jquery.min');
     OCP\Util::addStyle('calendar', '../3rdparty/chosen/css/chosen');

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -37,3 +37,13 @@ OCP\Share::registerBackend('event', 'OC_Share_Backend_Event');
 Sabre\VObject\Property::$classMap['SUMMARY'] = 'OC\VObject\StringProperty';
 Sabre\VObject\Property::$classMap['DESCRIPTION'] = 'OC\VObject\StringProperty';
 Sabre\VObject\Property::$classMap['LOCATION'] = 'OC\VObject\StringProperty';
+
+$url = OC::$server->getRequest()->server['REQUEST_URI'];
+
+if (preg_match('%index.php/apps/files/?.*%', $url)) {
+    OCP\Util::addscript('calendar','loader');
+    OCP\Util::addScript('calendar', '../3rdparty/chosen/js/chosen.jquery.min');
+    OCP\Util::addStyle('calendar', '../3rdparty/chosen/css/chosen');
+    OCP\Util::addStyle('calendar', '../3rdparty/miniColors/css/jquery.miniColors');
+    OCP\Util::addscript('calendar', '../3rdparty/miniColors/js/jquery.miniColors.min');
+}

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -24,11 +24,6 @@ OCP\Util::connectHook('OC_Calendar', 'deleteEvent', 'OC_Calendar_Repeat', 'clean
 OCP\Util::connectHook('OC_Calendar', 'moveEvent', 'OC_Calendar_Repeat', 'update');
 OCP\Util::connectHook('OC_Calendar', 'deleteCalendar', 'OC_Calendar_Repeat', 'cleanCalendar');
 
-OCP\Util::addscript('calendar','loader');
-OCP\Util::addScript('calendar/3rdparty/chosen', 'chosen.jquery.min');
-OCP\Util::addStyle('calendar/3rdparty/chosen', 'chosen');
-OCP\Util::addStyle('calendar/3rdparty/miniColors', 'jquery.miniColors');
-OCP\Util::addscript('calendar/3rdparty/miniColors', 'jquery.miniColors.min');
 OCP\App::addNavigationEntry( array(
   'id' => 'calendar_index',
   'order' => 10,

--- a/index.php
+++ b/index.php
@@ -26,12 +26,6 @@ if(OCP\Config::getUserValue(OCP\USER::getUser(), 'calendar', 'currentview', 'mon
 	OCP\Config::setUserValue(OCP\USER::getUser(), "calendar", "currentview", "list");
 }
 
-OCP\Util::addscript('calendar','loader');
-OCP\Util::addScript('calendar', '../3rdparty/chosen/js/chosen.jquery.min');
-OCP\Util::addStyle('calendar', '../3rdparty/chosen/css/chosen');
-OCP\Util::addStyle('calendar', '../3rdparty/miniColors/css/jquery.miniColors');
-OCP\Util::addscript('calendar', '../3rdparty/miniColors/js/jquery.miniColors.min');
-
 OCP\Util::addScript('calendar', '../3rdparty/fullcalendar/js/fullcalendar');
 OCP\Util::addStyle('calendar', '../3rdparty/fullcalendar/css/fullcalendar');
 OCP\Util::addScript('calendar', '../3rdparty/timepicker/js/jquery.ui.timepicker');

--- a/index.php
+++ b/index.php
@@ -26,21 +26,27 @@ if(OCP\Config::getUserValue(OCP\USER::getUser(), 'calendar', 'currentview', 'mon
 	OCP\Config::setUserValue(OCP\USER::getUser(), "calendar", "currentview", "list");
 }
 
-OCP\Util::addscript('calendar/3rdparty/fullcalendar', 'fullcalendar');
-OCP\Util::addStyle('calendar/3rdparty/fullcalendar', 'fullcalendar');
-OCP\Util::addscript('calendar/3rdparty/timepicker', 'jquery.ui.timepicker');
-OCP\Util::addStyle('calendar/3rdparty/timepicker', 'jquery.ui.timepicker');
+OCP\Util::addscript('calendar','loader');
+OCP\Util::addScript('calendar', '../3rdparty/chosen/js/chosen.jquery.min');
+OCP\Util::addStyle('calendar', '../3rdparty/chosen/css/chosen');
+OCP\Util::addStyle('calendar', '../3rdparty/miniColors/css/jquery.miniColors');
+OCP\Util::addscript('calendar', '../3rdparty/miniColors/js/jquery.miniColors.min');
+
+OCP\Util::addScript('calendar', '../3rdparty/fullcalendar/js/fullcalendar');
+OCP\Util::addStyle('calendar', '../3rdparty/fullcalendar/css/fullcalendar');
+OCP\Util::addScript('calendar', '../3rdparty/timepicker/js/jquery.ui.timepicker');
+OCP\Util::addStyle('calendar', '../3rdparty/timepicker/css/jquery.ui.timepicker');
 if(OCP\Config::getUserValue(OCP\USER::getUser(), "calendar", "timezone") == null || OCP\Config::getUserValue(OCP\USER::getUser(), 'calendar', 'timezonedetection') == 'true') {
-	OCP\Util::addscript('calendar', 'geo');
+	OCP\Util::addScript('calendar', 'geo');
 }
-OCP\Util::addscript('calendar', 'calendar');
+OCP\Util::addScript('calendar', 'calendar');
 OCP\Util::addStyle('calendar', 'style');
-OCP\Util::addscript('calendar/3rdparty/jquery.multiselect', 'jquery.multiselect');
-OCP\Util::addStyle('calendar/3rdparty/jquery.multiselect', 'jquery.multiselect');
-OCP\Util::addscript('calendar','jquery.multi-autocomplete');
-OCP\Util::addscript('','tags');
-OCP\Util::addscript('calendar','on-event');
-OCP\Util::addscript('calendar','settings');
+OCP\Util::addScript('calendar', '../3rdparty/jquery.multiselect/js/jquery.multiselect');
+OCP\Util::addStyle('calendar', '../3rdparty/jquery.multiselect/css/jquery.multiselect');
+OCP\Util::addScript('calendar','jquery.multi-autocomplete');
+OCP\Util::addScript('','tags');
+OCP\Util::addScript('calendar','on-event');
+OCP\Util::addScript('calendar','settings');
 OCP\App::setActiveNavigationEntry('calendar_index');
 $tmpl = new OCP\Template('calendar', 'calendar', 'user');
 $timezone=OCP\Config::getUserValue(OCP\USER::getUser(),'calendar','timezone','');


### PR DESCRIPTION
Moves all scripts and styles to index.php so that they are only loaded when the calendar is actually opened and not when you launch the News app for instance. Also the first paramter to addScript is the application name and this breaks various things in core if you just use a hack like the path

@georgehrke @raghunayyar 
