### PR TITLE
event-description maximum width added

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -187,6 +187,7 @@ button.category{margin:0 3px;}
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 	width: 100%;
+	max-width: 100%;
 	margin: 3px 0;
 }
 /* bigger event title in detail view */


### PR DESCRIPTION
To prevent expanding the text boxes width too wide, I added a `max-width` property

Screenshot of an expanded text box:
![oc_max_width](https://cloud.githubusercontent.com/assets/1374172/5940813/7b45f478-a70d-11e4-9e03-206687a9f0c2.png)
Tested with Firefox 35.0.1
