### PR TITLE
fix event dialog position and size on mobile, fix #703

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -251,6 +251,8 @@ button.category{margin:0 3px;}
 	overflow-y: auto;
 	overflow-x: hidden;
 	padding: 0;
+	z-index: 1000;
+	max-width: 100%;
 }
 .ui-dialog .ui-dialog-content {
 	overflow: initial;


### PR DESCRIPTION
@ericcotelnu this should fix https://github.com/owncloud/calendar/issues/703

Please also review @owncloud/designers @georgehrke @brantje 

We should also backport this cause it’s a pretty serious bug which prevents from creating events on mobile.
