### PR TITLE
Fix error message for cron run

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -38,12 +38,15 @@ Sabre\VObject\Property::$classMap['SUMMARY'] = 'OC\VObject\StringProperty';
 Sabre\VObject\Property::$classMap['DESCRIPTION'] = 'OC\VObject\StringProperty';
 Sabre\VObject\Property::$classMap['LOCATION'] = 'OC\VObject\StringProperty';
 
-$url = OC::$server->getRequest()->server['REQUEST_URI'];
+$request = \OC::$server->getRequest();
+if (isset($request->server['REQUEST_URI'])) {
+	$url = $request->server['REQUEST_URI'];
 
-if (preg_match('%index.php/apps/files(/.*)?%', $url)) {
-    OCP\Util::addscript('calendar','loader');
-    OCP\Util::addScript('calendar', '../3rdparty/chosen/js/chosen.jquery.min');
-    OCP\Util::addStyle('calendar', '../3rdparty/chosen/css/chosen');
-    OCP\Util::addStyle('calendar', '../3rdparty/miniColors/css/jquery.miniColors');
-    OCP\Util::addscript('calendar', '../3rdparty/miniColors/js/jquery.miniColors.min');
+	if (preg_match('%index.php/apps/files(/.*)?%', $url)) {
+		OCP\Util::addScript('calendar', 'loader');
+		OCP\Util::addScript('calendar', '../3rdparty/chosen/js/chosen.jquery.min');
+		OCP\Util::addStyle('calendar', '../3rdparty/chosen/css/chosen');
+		OCP\Util::addStyle('calendar', '../3rdparty/miniColors/css/jquery.miniColors');
+		OCP\Util::addscript('calendar', '../3rdparty/miniColors/js/jquery.miniColors.min');
+	}
 }


### PR DESCRIPTION
For every cron run there is no request URI set. This checks for the existence before accessing it.

backport to stable8 would be nice, because this pollutes the log.

cc @georgehrke @Raydiation 

To test:
- Activate calendar
- run php -f cron.php before and after this

Error message was:

```
{"reqId":"3b72eb1fd612fa6bc4f01721ca6dddfa","remoteAddr":"","app":"PHP","message":"Undefined index: REQUEST_URI at \/home\/mjob\/Projekte\/owncloud\/master\/apps2\/calendar\/appinfo\/app.php#41","level":0,"time":"2015-03-18T09:50:56+00:00","method":"--","url":"--"}
```
