### PR TITLE
Don't override default today highlight colour with JS

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1043,7 +1043,8 @@ $(document).ready(function(){
 			if(view.name === 'agendaDay') {
 				$('td.fc-state-highlight').css('background-color', '#ffffff');
 			} else{
-				$('td.fc-state-highlight').css('background-color', '#ffc');
+				// remove any custom CSS. Fall back to default for .fc-state-highlight (style.css)
+				$('td.fc-state-highlight').css('background-color', '');
 			}
 			Calendar.UI.setViewActive(view.name);
 			if (view.name == 'agendaWeek') {


### PR DESCRIPTION
Fixes #757 

I decided in the end that it would be wiser to remove any custom-set attribute all together, and fall back to the one defined [in style.css](https://github.com/owncloud/calendar/blob/master/css/style.css#L113)

CC @georgehrke
