### PR TITLE
Fix calendar deletion while deleting users by command line

### DIFF
--- a/lib/calendar.php
+++ b/lib/calendar.php
@@ -418,6 +418,10 @@ class OC_Calendar_Calendar{
 	private static function isAllowedToDeleteCalendar($calendar) {
 		$userId = OCP\User::getUser();
 
+		//in case it is called by command line or cron
+		if($userId == '') {
+			return true;
+		}
 		if ($calendar['userid'] === $userId) {
 			return true;
 		}


### PR DESCRIPTION
This patch fixes the calender deletion while deleting users by command line or cron.

I did not found a proper method whether to detect if this function is called by the command line or cron job but I think this changes should solve the problem too because the userId is set always except of calls from command line or cron.
