### PR TITLE
Fixed ajax import script to resolve #843

### DIFF
--- a/ajax/import/import.php
+++ b/ajax/import/import.php
@@ -10,7 +10,7 @@ OCP\App::checkAppEnabled('calendar');
 OCP\JSON::callCheck();
 session_write_close();
 if (isset($_POST['progresskey']) && isset($_POST['getprogress'])) {
-	echo OCP\JSON::success(array('percent'=>\OC\Cache::get($_POST['progresskey'])));
+	echo OCP\JSON::success(array('percent'=>\OC::$server->getCache()->get($_POST['progresskey'])));
 	exit;
 }
 $file = \OC\Files\Filesystem::file_get_contents($_POST['path'] . '/' . $_POST['file']);


### PR DESCRIPTION
Hi @georgehrke, it turns out that you overlooked an instance of \OC::Cache in the ajax import backend. I have provided the following change to fix the issue.
