### PR TITLE
Removed line causing wrong DTEND value

### DIFF
--- a/lib/import.php
+++ b/lib/import.php
@@ -126,7 +126,6 @@ class OC_Calendar_Import{
 			if(!is_null($object->DTSTART)){
 				$dtend = OC_Calendar_Object::getDTEndFromVEvent($object);
 				if($object->DTEND) {
-					$object->DTEND['VALUE'] = $object->DTSTART['VALUE'];
 					$dtend = $dtend->getDateTime();
 					$dtend->setTimeZone($object->DTSTART->getDateTime()->getTimeZone());
 					$object->DTEND->setDateTime($dtend);


### PR DESCRIPTION
Fixes #849 and #868.
This line caused a new parameter to be created in `$objects->DTEND` with the name 'VALUE', which never gets used afterwards.
In the `serialize()` method this lead to the not needed "VALUE=" string in each event.

@msedv @Xarfay @polcape Does this fix your problems?
