### PR TITLE
Fix some tests, typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ To run the build tasks, we use gruntjs tasks which can be installed via npm as
 > npm install
 
 Building SASS and JS
-grunt build
+> grunt build
 
 Watching SASS and JS
-grunt watch
+> grunt watch
 
 Coming Soon: running JS tests.
 

--- a/build/Gruntfile.js
+++ b/build/Gruntfile.js
@@ -111,9 +111,10 @@ module.exports = function(grunt) {
 
 		phpunit: {
 			classes: {
-				dir: '../tests/php/unit'
+				dir: '../tests/unit'
 			},
 			options: {
+				bootstrap: '../tests/bootstrap.php',
 				colors: true
 			}
 		},

--- a/db/backendcollection.php
+++ b/db/backendcollection.php
@@ -63,7 +63,7 @@ class BackendCollection extends Collection implements IBackendCollection {
 
 
 	/**
-	 * Search for a backend by it's name
+	 * Search for a backend by its name
 	 * @param string $id
 	 * @return IBackend|null
 	 */

--- a/tests/unit/backend/contact/backendTest.php
+++ b/tests/unit/backend/contact/backendTest.php
@@ -28,7 +28,8 @@ class BackendTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public $backend;
 
-	public function setup() {
+	public function setUp() {
+		parent::setUp();
 		$contactManager = $this->getMock('\OCP\Contacts\IManager');
 		$this->backend = new Backend($contactManager);
 	}

--- a/tests/unit/utility/utilityTest.php
+++ b/tests/unit/utility/utilityTest.php
@@ -38,7 +38,7 @@ class UtilityTest extends \PHPUnit_Framework_TestCase {
 			['test ', 'test'],
 			['test 1', 'test-1'],
 			['te!@#$%^&*()_+st', 'te-st'],
-			['äöü', 'aeoeue'],
+			['äöü', 'aou'],
 		];
 	}
 


### PR DESCRIPTION
fix slugify test: on my system as well as on travis, "äöü" gets converted to "aou", not "aeoeue" (except if I manually change the locale to de_AT.utf8 first).
