### PR TITLE
Use rawurlencode to encode spaces in user names

### DIFF
--- a/templates/calendar.php
+++ b/templates/calendar.php
@@ -106,7 +106,7 @@
 				</li>
 				<li>
 					<label class="bold"><?php p($l->t('iOS/OS X CalDAV address')); ?></label>
-					<input id="ioscaldav" type="text" value="<?php print_unescaped(OCP\Util::linkToRemote('caldav')); ?>principals/<?php p(urlencode(OCP\USER::getUser())); ?>/" style="width:90%" readonly>
+					<input id="ioscaldav" type="text" value="<?php print_unescaped(OCP\Util::linkToRemote('caldav')); ?>principals/<?php p(rawurlencode(OCP\USER::getUser())); ?>/" style="width:90%" readonly>
 				</li>
 			</ul>
 		</div>


### PR DESCRIPTION
Use rawurlencode to encode spaces in user names as %20 instead of + to be put into the iOS CalDAV url in the frontend.
The + encoding is ambiguous and it will be considered part of the user name if passed to caldav. Thus it looks for user 'First+Last' instead of 'First Last'. 
