### PR TITLE
Added setting to enable/disable contact birthdays

### DIFF
--- a/ajax/settings/contactbirthdays.php
+++ b/ajax/settings/contactbirthdays.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright (c) 2011, 2012 Georg Ehrke <ownclouddev at georgswebsite dot de>
+ * Copyright (c) 2015 Felix Tiede <info at pc-tiede dot de>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+OCP\JSON::checkLoggedIn();
+OCP\JSON::checkAppEnabled('calendar');
+OCP\JSON::checkAppEnabled('contacts');
+OCP\JSON::callCheck();
+if(array_key_exists('contactbirthdays', $_POST) && $_POST['contactbirthdays'] == 'on') {
+	OCP\Config::setUserValue(OCP\USER::getUser(), 'calendar', 'contactbirthdays', 'true');
+}else{
+	OCP\Config::setUserValue(OCP\USER::getUser(), 'calendar', 'contactbirthdays', 'false');
+}
+OCP\JSON::success();

--- a/ajax/settings/getcontactbirthdays.php
+++ b/ajax/settings/getcontactbirthdays.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Copyright (c) 2011, 2012 Georg Ehrke <ownclouddev at georgswebsite dot de>
+ * Copyright (c) 2015 Felix Tiede <info at pc-tiede dot de>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+OCP\JSON::checkLoggedIn();
+OCP\JSON::checkAppEnabled('calendar');
+OCP\JSON::checkAppEnabled('contacts');
+OCP\JSON::success(array('birthdays' => OCP\Config::getUserValue(OCP\USER::getUser(), 'calendar', 'contactbirthdays')));

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -94,6 +94,14 @@ $this->create('calendar_import_import', 'ajax/import/import.php')
 
 // /ajax/settings
 
+if(\OCP\App::isEnabled('contacts')) {
+	$this->create('calendar_settings_getcontactbirthdays', 'ajax/settings/getcontactbirthdays.php')
+		->actionInclude('calendar/ajax/settings/getcontactbirthdays.php');
+
+	$this->create('calendar_settings_setcontactbirthdays', 'ajax/settings/contactbirthdays.php')
+		->actionInclude('calendar/ajax/settings/contactbirthdays.php');
+}
+
 $this->create('calendar_settings_getfirstday', 'ajax/settings/getfirstday.php')
 	->actionInclude('calendar/ajax/settings/getfirstday.php');
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -26,6 +26,12 @@ $(document).ready(function(){
 
 		});
 	});
+	$('#contactbirthdays').change( function(){
+		var post = $('#contactbirthdays').serialize();
+		$.post( OC.filePath('calendar', 'ajax/settings', 'contactbirthdays.php'), post, function(data){
+
+		});
+	});
 	$.getJSON(OC.filePath('calendar', 'ajax/settings', 'timeformat.php'), function(jsondata, status) {
 		$('#' + jsondata.timeformat).attr('selected',true);
 		$('#timeformat_chzn').css('width', '100px');
@@ -38,6 +44,11 @@ $(document).ready(function(){
 	$.getJSON(OC.filePath('calendar', 'ajax/settings', 'getfirstday.php'), function(jsondata, status) {
 		$('#' + jsondata.firstday).attr('selected',true);
 		$('#firstday_chzn').css('width', '100px');
+	});
+	$.getJSON(OC.filePath('calendar', 'ajax/settings', 'getcontactbirthdays.php'), function(jsondata, status) {
+		if(jsondata.birthdays == 'true'){
+			$('#contactbirthdays').attr('checked', 'checked');
+		}
 	});
 	$('#cleancalendarcache').click(function(){
 		$.getJSON(OC.filePath('calendar', 'ajax/cache', 'rescan.php'), function(){

--- a/lib/sabre/backend.php
+++ b/lib/sabre/backend.php
@@ -60,7 +60,8 @@ class OC_Connector_Sabre_CalDAV extends \Sabre\CalDAV\Backend\AbstractBackend {
 
 			$calendars[] = $calendar;
 		}
-		if(\OCP\App::isEnabled('contacts')) {
+		if(\OCP\App::isEnabled('contacts') &&
+				OCP\Config::getUserValue(OCP\USER::getUser(), 'calendar', 'contactbirthdays') == 'true') {
 			$ctag = 0;
 			$app = new \OCA\Contacts\App();
 			$addressBooks = $app->getAddressBooksForUser();

--- a/templates/calendar.php
+++ b/templates/calendar.php
@@ -51,6 +51,12 @@
 		</div>
 		<div id="app-settings-content">
 			<ul>
+				<?php if(\OCP\App::isEnabled('contacts')): ?>
+				<li>
+					<input type="checkbox" name="contactbirthdays" id="contactbirthdays">
+					<label class="bold" for="contactbirthdays"><?php p($l->t('Contact birthdays')); ?></label>
+				</li>
+				<?php endif; ?>
 				<li>
 					<label for="timezone" class="bold"><?php p($l->t('Timezone')); ?></label>
 					<select id="timezone" name="timezone">


### PR DESCRIPTION
By default calendar app exports a special calendar containing all
contact's birthdays. For users who use clients with their own linking
between addressbooks and calendars, f.ex. Thunderbird, kontact, Android
with Birthday Calendar adapter, this produces overhead.

This change introduces a global setting inside ownCloud's calendar app
to disable this feature.
