### PR TITLE
Fix short forms of weekday and month names

### DIFF
--- a/js/share.js
+++ b/js/share.js
@@ -835,10 +835,10 @@
 			minDate.setDate(minDate.getDate()+1);
 			$.datepicker.setDefaults({
 				monthNames: monthNames,
-				monthNamesShort: $.map(monthNames, function(v) { return v.slice(0,3)+'.'; }),
+				monthNamesShort: monthNamesShort,
 				dayNames: dayNames,
-				dayNamesMin: $.map(dayNames, function(v) { return v.slice(0,2); }),
-				dayNamesShort: $.map(dayNames, function(v) { return v.slice(0,3)+'.'; }),
+				dayNamesMin: dayNamesMin,
+				dayNamesShort: dayNamesShort,
 				firstDay: firstDay,
 				minDate : minDate
 			});


### PR DESCRIPTION
This applies the fix already in the core (acc5a7d) to the local copy.
Should fix a weekdays problem mentioned in #476, #891 and possible more.
