### PR TITLE
Prevent hour 24 and minute 60

### DIFF
--- a/lib/object.php
+++ b/lib/object.php
@@ -872,8 +872,8 @@ class OC_Calendar_Object{
 		}
 		list($hours, $minutes) = explode(':', $time);
 		return empty($time)
-			|| $hours < 0 || $hours > 24
-			|| $minutes < 0 || $minutes > 60;
+			|| $hours < 0 || $hours > 23
+			|| $minutes < 0 || $minutes > 59;
 	}
 
 	/**


### PR DESCRIPTION
It seems to me that checkTime will currently allow a time like "09:60" or "24:00" or "24:01" or even "24:60"
Maybe 24:00 is allowable? Does that indicate the end of a day, as compared to the same time "00:00" of the next day?

But minutes of "60" would always be invalid. And a "24" hour with minutes other than "00" is also invalid.
