### PR TITLE
Fix: Call to undefined method OC_Helper::linkTo()

### DIFF
--- a/templates/calendar.php
+++ b/templates/calendar.php
@@ -1,4 +1,4 @@
-<script type="text/javascript" src="<?php print_unescaped(OC_Helper::linkTo('calendar/js', 'l10n.php'));?>"></script>
+<script type="text/javascript" src="<?php print_unescaped(\OC::$server->getURLGenerator()->linkTo('calendar', '/js/l10n.php'));?>"></script>
 
 <div id="notification" style="display:none;"></div>
 <div id="app-navigation">


### PR DESCRIPTION
Fixes #1018 (Error: Call to undefined method OC_Helper::linkTo() )
Needed because of: https://github.com/owncloud/core/pull/21253 (Remove deprecated OC_Helper::linkTo)

@DeepDiver1975 @rullzer 
